### PR TITLE
Fixes ThrowItem not working with item(s) has DiscardLimit

### DIFF
--- a/Source/Coop/Player/PlayerInventoryController_ThrowItem_Patch.cs
+++ b/Source/Coop/Player/PlayerInventoryController_ThrowItem_Patch.cs
@@ -93,10 +93,7 @@ namespace SIT.Core.Coop.Player
                 {
                     EFT.Player.PlayerInventoryController playerInventoryController = itemController as EFT.Player.PlayerInventoryController;
                     if (playerInventoryController == null)
-                    {
                         playerInventoryController = new(player, player.Profile, false);
-                        playerInventoryController.ResetDiscardLimits();
-                    }
 
                     List<ItemsCount> destroyedItems = GetDestroyedItemsFromItem(playerInventoryController, item);
                     if (destroyedItems.Count != 0)
@@ -127,8 +124,13 @@ namespace SIT.Core.Coop.Player
         {
             List<ItemsCount> destroyedItems = new();
 
-            if (playerInventoryController.HasDiscardLimit(item, out int itemDiscardLimit) && item.StackObjectsCount > itemDiscardLimit)
-                destroyedItems.Add(new ItemsCount(item, item.StackObjectsCount - itemDiscardLimit, itemDiscardLimit));
+            //if (playerInventoryController.HasDiscardLimit(item, out int itemDiscardLimit) && item.StackObjectsCount > itemDiscardLimit)
+            if (playerInventoryController.HasDiscardLimits && item.LimitedDiscard)
+            {
+                int itemDiscardLimit = item.DiscardLimit.Value;
+                if (item.StackObjectsCount > itemDiscardLimit)
+                    destroyedItems.Add(new ItemsCount(item, item.StackObjectsCount - itemDiscardLimit, itemDiscardLimit));
+            }
 
             if (item.IsContainer && destroyedItems.Count == 0)
             {
@@ -143,8 +145,11 @@ namespace SIT.Core.Coop.Player
                         if (itemInContainer == item)
                             continue;
 
-                        if (playerInventoryController.HasDiscardLimit(itemInContainer, out int itemInContainerDiscardLimit))
+                        //if (playerInventoryController.HasDiscardLimit(itemInContainer, out int itemInContainerDiscardLimit))
+                        if (playerInventoryController.HasDiscardLimits && itemInContainer.LimitedDiscard)
                         {
+                            int itemInContainerDiscardLimit = itemInContainer.DiscardLimit.Value;
+
                             if (!destroyedItems.Any(x => x.Item.TemplateId == itemInContainer.TemplateId))
                             {
                                 string templateId = itemInContainer.TemplateId;

--- a/Source/Coop/Player/Player_DropBackpack_Patch.cs
+++ b/Source/Coop/Player/Player_DropBackpack_Patch.cs
@@ -58,14 +58,9 @@ namespace SIT.Coop.Core.Player
 
             EFT.Player.PlayerInventoryController playerInventoryController = itemController as EFT.Player.PlayerInventoryController;
             if (playerInventoryController == null)
-            {
                 playerInventoryController = new(__instance, __instance.Profile, false);
-                playerInventoryController.ResetDiscardLimits();
-            }
 
-            if (PlayerInventoryController_ThrowItem_Patch.CallLocally.Contains(__instance.ProfileId))
-                PlayerInventoryController_ThrowItem_Patch.CallLocally.Remove(__instance.ProfileId);
-
+            PlayerInventoryController_ThrowItem_Patch.CallLocally.Remove(__instance.ProfileId);
             PlayerInventoryController_ThrowItem_Patch.PostPatch(playerInventoryController, backpack, __instance.Profile);
         }
 


### PR DESCRIPTION
BSG fu*ked up their `EFT.Player.PlayerInventoryController.DiscardLimits[]` in the latest version, and ThrowItem need it before, now it doesn't.