### PR TITLE
Fixed JoinMatch

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -477,10 +477,9 @@ namespace SIT.Core.Coop.Components
                 Logger.LogDebug(returnedJson);
                 JObject result = JObject.Parse(returnedJson);
                 MatchmakerAcceptPatches.SetGroupId(result["serverId"].ToString());
-                MatchmakerAcceptPatches.SetTimestamp(long.Parse(result["timestamp"].ToString()));
+                //MatchmakerAcceptPatches.SetTimestamp(long.Parse(result["timestamp"].ToString()));
                 MatchmakerAcceptPatches.MatchingType = EMatchmakerType.GroupPlayer;
                 MatchmakerAcceptPatches.HostExpectedNumberOfPlayers = int.Parse(result["expectedNumberOfPlayers"].ToString());
-
                 AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile);
 
                 FixesHideoutMusclePain();


### PR DESCRIPTION
Fixed crashing of JoinMatch function - there is no timestamp element in the returned JSON and it's not used anyway? Just commented-out for the moment