### PR TITLE
Add and Consume Player Packet Handlers via Player Replication Component

### DIFF
--- a/Source/Coop/Components/PlayerReplicatedComponent.cs
+++ b/Source/Coop/Components/PlayerReplicatedComponent.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS0618 // Type or member is obsolete
+using BepInEx.Logging;
 using EFT;
 using EFT.HealthSystem;
 using EFT.InventoryLogic;
@@ -11,6 +12,8 @@ using SIT.Tarkov.Core;
 using StayInTarkov;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using UnityEngine;
@@ -21,7 +24,7 @@ namespace SIT.Coop.Core.Player
     /// <summary>
     /// Player Replicated Component is the Player/AI direct communication to the Server
     /// </summary>
-    internal class PlayerReplicatedComponent : MonoBehaviour, IPlayerPacketHandlerComponent
+    internal class PlayerReplicatedComponent : MonoBehaviour
     {
         internal const int PacketTimeoutInSeconds = 1;
         //internal ConcurrentQueue<Dictionary<string, object>> QueuedPackets { get; } = new();
@@ -39,6 +42,10 @@ namespace SIT.Coop.Core.Player
         void Awake()
         {
             //PatchConstants.Logger.LogDebug("PlayerReplicatedComponent:Awake");
+            // ----------------------------------------------------
+            // Create a BepInEx Logger for CoopGameComponent
+            Logger = BepInEx.Logging.Logger.CreateLogSource(nameof(PlayerReplicatedComponent));
+            Logger.LogDebug($"{nameof(PlayerReplicatedComponent)}:Awake");
         }
 
         void Start()
@@ -99,7 +106,23 @@ namespace SIT.Coop.Core.Player
 
             // TODO: Add PacketHandlerComponents here. Possibly via Reflection?
             //PacketHandlerComponents.Add(new MoveOperationPlayerPacketHandler());
+            var packetHandlers = Assembly.GetAssembly(typeof(IPlayerPacketHandlerComponent))
+               .GetTypes()
+               .Where(x => x.GetInterface(nameof(IPlayerPacketHandlerComponent)) != null);
+            foreach (var handler in packetHandlers)
+            {
+                if (handler.IsAbstract
+                    || handler == typeof(IPlayerPacketHandlerComponent)
+                    || handler.Name == nameof(IPlayerPacketHandlerComponent)
+                    )
+                    continue;
 
+                if (PacketHandlerComponents.Any(x => x.GetType().Name == handler.Name))
+                    continue;
+
+                PacketHandlerComponents.Add((IPlayerPacketHandlerComponent)Activator.CreateInstance(handler));
+                Logger.LogDebug($"Added {handler.Name} to {nameof(PacketHandlerComponents)}");
+            }
         }
 
         public void ProcessPacket(Dictionary<string, object> packet)
@@ -111,6 +134,11 @@ namespace SIT.Coop.Core.Player
 
             ProcessPlayerState(packet);
 
+            // Iterate through the PacketHandlerComponents
+            foreach (var packetHandlerComponent in PacketHandlerComponents)
+            {
+                packetHandlerComponent.ProcessPacket(packet);
+            }
 
             if (!ModuleReplicationPatch.Patches.ContainsKey(method))
                 return;
@@ -122,13 +150,7 @@ namespace SIT.Coop.Core.Player
                 return;
             }
 
-            if (PacketHandlerComponents != null)
-            {
-                foreach (var packetHandlerComponent in PacketHandlerComponents)
-                {
-                    packetHandlerComponent.ProcessPacket(packet);
-                }
-            }
+          
         }
 
         void ProcessPlayerState(Dictionary<string, object> packet)
@@ -435,6 +457,7 @@ namespace SIT.Coop.Core.Player
         public float LastSpeed { get; private set; }
         public DateTime LastPlayerStateSent { get; private set; } = DateTime.Now;
         public bool TriggerPressed { get; internal set; }
+        public ManualLogSource Logger { get; private set; }
 
         public Dictionary<string, object> PreMadeMoveDataPacket = new()
         {

--- a/Source/Coop/PacketHandlers/ExamplePlayerPacketHandler.cs
+++ b/Source/Coop/PacketHandlers/ExamplePlayerPacketHandler.cs
@@ -1,0 +1,54 @@
+﻿using EFT;
+using Newtonsoft.Json;
+using SIT.Core.Coop.Components;
+using SIT.Core.Coop.NetworkPacket;
+using SIT.Tarkov.Core;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace SIT.Core.Coop.PacketHandlers
+{
+    /// <summary>
+    /// Created by Paulov
+    /// Description: Here is an example of how to use IPlayerPacketHandlerComponent. You contract the interface and then use ProcessPacket to do the work.
+    /// </summary>
+    internal class ExamplePlayerPacketHandler : IPlayerPacketHandlerComponent
+    {
+        private CoopGameComponent CoopGameComponent { get { CoopGameComponent.TryGetCoopGameComponent(out var coopGC); return coopGC; } }
+        public ConcurrentDictionary<string, EFT.Player> Players => CoopGameComponent.Players;
+
+        private BepInEx.Logging.ManualLogSource Logger { get; set; }
+
+        public ExamplePlayerPacketHandler()
+        {
+            Logger = BepInEx.Logging.Logger.CreateLogSource(nameof(ExamplePlayerPacketHandler));
+        }
+
+        public void ProcessPacket(Dictionary<string, object> packet)
+        {
+            string profileId = null;
+            string method = null;
+
+            if (!packet.ContainsKey("profileId"))
+                return;
+
+            profileId = packet["profileId"].ToString();
+
+            if (!packet.ContainsKey("m"))
+                return;
+
+            method = packet["m"].ToString();
+
+            // Now Process dependant on the Packet
+            // e.g. if (packet["m"].ToString() == "MoveOperation")
+
+            //Logger.LogInfo(packet.SITToJson());
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds the ability to use custom "Player Packet Handlers" for any action that a Player can consume. 

This allows someone to abstract away from the Module Replication Patch so a developer can directly target the CoopPlayer class without the MRP loop. This will also enable developers to refactor any Player BepInEx patches into directly calling using the CoopPlayer class.

The IPlayerPacketHandlerComponent is automatically found and consumed by each processed packet from the WebSocket.

I've included an "ExamplePlayerPacketHandler". This is a small extract of what I am using for ItemMovementReplication2.0.