### PR TITLE
Added ReadyButtonPatch

### DIFF
--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -266,6 +266,9 @@ namespace StayInTarkov
                 //// --------- SCAV MODE ---------------------
                 new RemoveScavModeButtonPatch().Enable();
 
+                //// --------- READY Button ---------------------
+                new RemoveReadyButtonPatch().Enable();
+
                 //// --------- Airdrop -----------------------
                 //new AirdropPatch().Enable();
 

--- a/Source/UI/RemoveReadyButtonPatch.cs
+++ b/Source/UI/RemoveReadyButtonPatch.cs
@@ -1,0 +1,39 @@
+﻿using EFT.UI;
+using EFT.UI.Matchmaker;
+using SIT.Tarkov.Core;
+using System.Reflection;
+using UnityEngine;
+
+namespace StayInTarkov.UI
+{
+    /// <summary>
+    /// Created by: Lacyway
+    /// </summary>
+    public class RemoveReadyButtonPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return typeof(MatchMakerSelectionLocationScreen).GetMethod("method_7", BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+
+        [PatchPostfix]
+        static void PatchPostfix()
+        {
+            var readyButton = GameObject.Find("ReadyButton");
+
+            if (readyButton != null)
+            {
+                DefaultUIButton uiButton = readyButton.GetComponent<DefaultUIButton>();
+
+                if (uiButton != null)
+                {
+                    if (uiButton.Interactable == true)
+                    {
+                        uiButton.Interactable = false;
+                        uiButton.SetDisabledTooltip("Disabled with SIT");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Disables the ready button as it throws an error

Maybe all small UI patches should be consolidated into one file? I.e. we put `RemoveScavModeButtonPatch` and `RemoveReadyButtonPatch` in the same file as they are small.