### PR TITLE
Fix ShowFeed flag

### DIFF
--- a/Source/Health/OnDeadPatch.cs
+++ b/Source/Health/OnDeadPatch.cs
@@ -19,7 +19,7 @@ namespace StayInTarkov.Health
 
         public OnDeadPatch(BepInEx.Configuration.ConfigFile config)
         {
-            var enableDeathMessage = config.Bind("SIT", "EnableDeathMessage", true);
+            var enableDeathMessage = config.Bind("Coop", "ShowFeed", true);
             if (enableDeathMessage != null)
             {
                 DisplayDeathMessage = enableDeathMessage.Value;

--- a/Source/Health/OnDeadPatch.cs
+++ b/Source/Health/OnDeadPatch.cs
@@ -1,5 +1,6 @@
 ﻿using EFT;
 using Newtonsoft.Json;
+using StayInTarkov.Configuration;
 using StayInTarkov.Networking;
 using StayInTarkov.UI;
 using System;
@@ -17,14 +18,9 @@ namespace StayInTarkov.Health
         public static event Action<Player, EDamageType> OnPersonKilled;
         public static bool DisplayDeathMessage = true;
 
-        public OnDeadPatch(BepInEx.Configuration.ConfigFile config)
+        public OnDeadPatch()
         {
-            var enableDeathMessage = config.Bind("Coop", "ShowFeed", true);
-            if (enableDeathMessage != null)
-            {
-                DisplayDeathMessage = enableDeathMessage.Value;
-
-            }
+            DisplayDeathMessage = PluginConfigSettings.Instance.CoopSettings.SETTING_ShowFeed;
         }
 
         protected override MethodBase GetTargetMethod() => ReflectionHelpers.GetMethodForType(typeof(Player), "OnDead");

--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -324,7 +324,7 @@ namespace StayInTarkov
             new ChangeHealthPatch().Enable();
             new ChangeHydrationPatch().Enable();
             new ChangeEnergyPatch().Enable();
-            new OnDeadPatch(Config).Enable();
+            new OnDeadPatch().Enable();
             new MainMenuControllerForHealthListenerPatch().Enable();
         }
 


### PR DESCRIPTION
there already exists a flag called `ShowFeed` (description: "Enable the feed on the bottom right of the screen which shows player/bot spawns, kills, etc."). This flag was not being used in favor of a new flag which resulted in confusion over how to enable/disable the kill feed. This PR restores the functionality of the original flag.

question: does anyone know how to remove the new `EnableDeathMessage` flag in the cfg file, so there is no confusion?