### PR TITLE
New SIT Garbage Collection based on memory usage

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -50,20 +50,26 @@ namespace StayInTarkov.Configuration
 
             public bool SITGCClearAssets { get; internal set; }
 
+            public bool SITGCAggressiveClean { get; internal set; }
+
             public void GetSettings()
             {
                 UseSITGarbageCollector = StayInTarkovPlugin.Instance.Config.Bind
                 ("Advanced", "UseSITGarbageCollector", true, new ConfigDescription("Whether to use the Garbage Collector developed in to SIT OR leave it to BSG/Unity")).Value;
 
                 SITGCMemoryThreshold = StayInTarkovPlugin.Instance.Config.Bind
-                ("Advanced", "SITGarbageCollectorMemoryThreshold", 1024, new ConfigDescription("The SIT Garbage Collector memory threshold (in megabytes) between ticks before forcing a garbage collection")).Value;
+                ("Advanced", "SITGarbageCollectorMemoryThreshold", 512, new ConfigDescription("The SIT Garbage Collector memory threshold (in megabytes) between ticks before forcing a garbage collection")).Value;
 
                 SITGCClearAssets = StayInTarkovPlugin.Instance.Config.Bind
-                ("Advanced", "SITGarbageCollectorClearAssets", false, new ConfigDescription("Set SIT Garbage Collector to clear assets")).Value;
+                ("Advanced", "SITGarbageCollectorClearAssets", false, new ConfigDescription("Set SIT Garbage Collector to clear Unity assets. Reduces RAM usage but can be unstable!")).Value;
+
+                SITGCAggressiveClean = StayInTarkovPlugin.Instance.Config.Bind
+                ("Advanced", "SITGarbageCollectorAggressiveClean", false, new ConfigDescription("Set SIT Garbage Collector to aggresively clean RAM. This will signficantly reduce in Raid RAM usage at the expense of a 1-5s freeze.")).Value;
 
                 Logger.LogInfo($"UseSITGarbageCollector:{UseSITGarbageCollector}");
                 Logger.LogInfo($"SITGCMemoryThreshold:{SITGCMemoryThreshold}");
                 Logger.LogInfo($"SITGCClearAssets:{SITGCClearAssets}");
+                Logger.LogInfo($"SITGCAggressiveClean:{SITGCAggressiveClean}");
 
             }
         }

--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -261,18 +261,25 @@ namespace StayInTarkov.Coop
                     {
                         Logger.LogDebug($"Current Memory Allocated:{memory / 1024 / 1024}mb");
                         lastMemory = memory;
+                        Stopwatch sw = Stopwatch.StartNew();
 
                         GCHelpers.EnableGC();
-                        GC.GetTotalMemory(true);
-                        GCHelpers.DisableGC(true);
+                        if (PluginConfigSettings.Instance.AdvancedSettings.SITGCAggressiveClean)
+                        {
+                            GCHelpers.ClearGarbage(true, PluginConfigSettings.Instance.AdvancedSettings.SITGCClearAssets);
+                        }
+                        else
+                        {
+                            GC.GetTotalMemory(true);
+                            GCHelpers.DisableGC(true);
+                        }
 
                         var freedMemory = GC.GetTotalMemory(false);
                         Logger.LogDebug($"Freed {(freedMemory > 0 ? (freedMemory / 1024 / 1024) : 0)}mb in memory");
+                        Logger.LogDebug($"Garbage Collection took {sw.ElapsedMilliseconds}ms");
+                        sw.Stop();
+                        sw = null;
 
-                        if (PluginConfigSettings.Instance.AdvancedSettings.SITGCClearAssets)
-                        {
-                            GCHelpers.ClearGarbage(true, true);
-                        }
                     }
 
                 } while (RunAsyncTasks && PluginConfigSettings.Instance.AdvancedSettings.UseSITGarbageCollector);


### PR DESCRIPTION
This is to move away from the time based SIT Garbage Collection method to one that determines based on memory usage. 

The PeriodicGCEnableDisable method in CoopGameComponent has been changed to;

* Check the difference of memory between each run 
* Determine whether it should clear garbage dependant on a Config Value in Megabytes
* The ability to aggressively clear garbage, freeing significant amount of RAM

The new Aggressive Garbage Collection can reduce RAM usage on Streets from 14gb to 2-4gb with a caveat of a significant freeze (lock up). The occurrance of the freeze can be modified by the other new settings provided.

![image](https://github.com/stayintarkov/StayInTarkov.Client/assets/7080439/737fa665-3d6b-4711-96a2-ba0dfdcf4a16)

The [Advanced] section of com.sit.core.cfg now includes the following;

```
## Whether to use the Garbage Collector developed in to SIT OR leave it to BSG/Unity
# Setting type: Boolean
# Default value: true
UseSITGarbageCollector = true

## The SIT Garbage Collector memory threshold (in megabytes) between ticks before forcing a garbage collection
# Setting type: Int32
# Default value: 512
SITGarbageCollectorMemoryThreshold = 512

## Set SIT Garbage Collector to clear Unity assets. Reduces RAM usage but can be unstable!
# Setting type: Boolean
# Default value: false
SITGarbageCollectorClearAssets = false

## Set SIT Garbage Collector to aggresively clean RAM. This will signficantly reduce in Raid RAM usage at the expense of a 1-5s freeze.
# Setting type: Boolean
# Default value: false
SITGarbageCollectorAggressiveClean = true
```