### PR TITLE
Temp fix for shooting package being sent while sprinting

### DIFF
--- a/Source/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
+++ b/Source/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
@@ -69,6 +69,9 @@ namespace StayInTarkov.Coop.Player.FirearmControllerPatches
             if (player == null)
                 return;
 
+            if (player.IsSprintEnabled)
+                return;
+
             if (CallLocally.Contains(player.ProfileId))
             {
                 CallLocally = CallLocally.Where(x => x != player.ProfileId).ToList();


### PR DESCRIPTION
Tested with @mihaicm93 

Other issues detected (not related to this PR):
- After a jam, shooting completely stops for the remainder of the raid
- After sprinting and jumping, after you land the shots seem to stop at random