### PR TITLE
Adjusted Nametags and additional CamFx removed upon death

### DIFF
--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -1415,15 +1415,41 @@ namespace StayInTarkov.Coop
                 if (pl.IsYourPlayer && pl.HealthController.IsAlive)
                     continue;
 
-                Vector3 aboveBotHeadPos = pl.Position + (Vector3.up * (pl.HealthController.IsAlive ? 1.5f : 0.5f));
+                Vector3 aboveBotHeadPos = pl.PlayerBones.Pelvis.position + (Vector3.up * (pl.HealthController.IsAlive ? 1.1f : 0.3f));
                 Vector3 screenPos = Camera.current.WorldToScreenPoint(aboveBotHeadPos);
                 if (screenPos.z > 0)
                 {
                     rect.x = (screenPos.x * screenScale) - (rect.width / 2);
-                    rect.y = Screen.height - (screenPos.y * screenScale);
+                    rect.y = Screen.height - ((screenPos.y + rect.height / 2) * screenScale);
+
+                    GUIStyle labelStyle = middleLabelStyle;
+                    labelStyle.fontSize = 14;
+                    float labelOpacity = 1;
+                    float distanceToCenter = Vector3.Distance(screenPos, new Vector3(Screen.width, Screen.height, 0) / 2);
+                    
+                    if (distanceToCenter < 100)
+                    {
+                        labelOpacity = distanceToCenter / 100;
+                    }
+
+                    if (ownPlayer.HandsController.IsAiming)
+                    {
+                        labelOpacity *= 0.5f;
+                    }
+
+                    if (pl.HealthController.IsAlive)
+                    {
+                        var maxHealth = pl.HealthController.GetBodyPartHealth(EBodyPart.Common).Maximum;
+                        var currentHealth = pl.HealthController.GetBodyPartHealth(EBodyPart.Common).Current / maxHealth;
+                        labelStyle.normal.textColor = new Color(2.0f * (1 - currentHealth), 2.0f * currentHealth, 0, labelOpacity);
+                    }
+                    else
+                    {
+                        labelStyle.normal.textColor = new Color(255, 0, 0, labelOpacity);
+                    }
 
                     var distanceFromCamera = Math.Round(Vector3.Distance(Camera.current.gameObject.transform.position, pl.Position));
-                    GUI.Label(rect, $"{pl.Profile.Nickname} {distanceFromCamera}m", middleLabelStyle);
+                    GUI.Label(rect, $"{pl.Profile.Nickname} {distanceFromCamera}m", labelStyle);
                 }
             }
         }

--- a/Source/Coop/FreeCamera/FreeCameraController.cs
+++ b/Source/Coop/FreeCamera/FreeCameraController.cs
@@ -6,6 +6,7 @@ using HarmonyLib;
 using StayInTarkov.Configuration;
 using System;
 using UnityEngine;
+using UnityStandardAssets.ImageEffects;
 
 namespace StayInTarkov.Coop.FreeCamera
 {
@@ -154,6 +155,18 @@ namespace StayInTarkov.Coop.FreeCamera
                     if (ccWiggle != null)
                     {
                         ccWiggle.enabled = false;
+                    }
+
+                    var ccBlur = fpsCamInstance.EffectsController.GetComponent<CC_RadialBlur>();
+                    if (ccBlur != null)
+                    {
+                        ccBlur.enabled = false;
+                    }
+
+                    var mBlur = fpsCamInstance.EffectsController.GetComponent<MotionBlur>();
+                    if (mBlur != null)
+                    {
+                        mBlur.enabled = false;
                     }
 
                     var ccBlends = fpsCamInstance.EffectsController.GetComponents<CC_Blend>();

--- a/Source/Coop/FreeCamera/FreeCameraController.cs
+++ b/Source/Coop/FreeCamera/FreeCameraController.cs
@@ -149,6 +149,37 @@ namespace StayInTarkov.Coop.FreeCamera
                     {
                         eyeBurn.enabled = false;
                     }
+
+                    var ccWiggle = fpsCamInstance.EffectsController.GetComponent<CC_Wiggle>();
+                    if (ccWiggle != null)
+                    {
+                        ccWiggle.enabled = false;
+                    }
+
+                    var ccBlends = fpsCamInstance.EffectsController.GetComponents<CC_Blend>();
+                    if (ccBlends != null)
+                    {
+                        foreach (var b in ccBlends) 
+                        {
+                            b.enabled = false;
+                        }
+                    }
+
+                    var visor = fpsCamInstance.VisorEffect;
+                    if (fastBlur != null)
+                    {
+                        visor.enabled = false;
+                    }
+                    var night = fpsCamInstance.NightVision;
+                    if (night != null)
+                    {
+                        night.enabled = false;
+                    }
+                    var thermal = fpsCamInstance.ThermalVision;
+                    if (thermal != null)
+                    {
+                        thermal.enabled = false;
+                    }
                 }
             }
 


### PR DESCRIPTION
Here's a little something while I'm loosing my mind dealing with sprinting 🤣:

+ Adjusted nametags to be above players
+ Nametag color-coded to the players healthstatus
+ Nametags get opaque when near the center of the screen and/or player is aiming
+ Additional visual effects disabled upon death (visor, nvs, thermal etc.)

Short Demo:
[![IMAGE ALT TEXT](http://img.youtube.com/vi/iJvtAL8zqcE/0.jpg)](http://www.youtube.com/watch?v=iJvtAL8zqcE)