### PR TITLE
Improve movement fluidity and fixed Sprinting "skipping/sliding"

### DIFF
--- a/Source/Coop/PacketHandlers/PlayerRotatePacketHandler.cs
+++ b/Source/Coop/PacketHandlers/PlayerRotatePacketHandler.cs
@@ -1,0 +1,53 @@
+﻿using StayInTarkov.Coop.Components;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace StayInTarkov.Coop.PacketHandlers
+{
+    /// <summary>
+    /// Created by Paulov
+    /// Description: Here is an example of how to use IPlayerPacketHandlerComponent. You contract the interface and then use ProcessPacket to do the work.
+    /// </summary>
+    internal class PlayerRotatePacketHandler : IPlayerPacketHandlerComponent
+    {
+        private CoopGameComponent CoopGameComponent { get { CoopGameComponent.TryGetCoopGameComponent(out var coopGC); return coopGC; } }
+        public ConcurrentDictionary<string, EFT.Player> Players => CoopGameComponent.Players;
+
+        private BepInEx.Logging.ManualLogSource Logger { get; set; }
+
+        public PlayerRotatePacketHandler()
+        {
+            Logger = BepInEx.Logging.Logger.CreateLogSource(nameof(PlayerRotatePacketHandler));
+        }
+
+        public void ProcessPacket(Dictionary<string, object> packet)
+        {
+            string profileId = null;
+            string method = null;
+
+            if (!packet.ContainsKey("profileId"))
+                return;
+
+            profileId = packet["profileId"].ToString();
+
+            if (!packet.ContainsKey("m"))
+                return;
+
+            method = packet["m"].ToString();
+
+            // Now Process dependant on the Packet
+            // e.g. if (packet["m"].ToString() == "MoveOperation")
+            if (method != "PlayerRotate")
+                return;
+
+            //Logger.LogInfo(packet.SITToJson());
+
+            var x = float.Parse(packet["x"].ToString());
+            var y = float.Parse(packet["y"].ToString());
+            Vector2 rot = new Vector2(x, y);
+            ((CoopPlayer)Players[profileId]).ReceiveRotate(rot, false);
+        }
+
+    }
+}

--- a/Source/Coop/Player/Player_Move_Patch.cs
+++ b/Source/Coop/Player/Player_Move_Patch.cs
@@ -174,6 +174,7 @@ namespace StayInTarkov.Coop.Player
                 var replicationDistance = Vector3.Distance(ReplicatedPosition, player.Position);
                 if (replicationDistance >= 3)
                 {
+                    Logger.LogDebug($"{player.Profile.Nickname} replication distance {replicationDistance} is further than 3, Teleporting");
                     player.Teleport(ReplicatedPosition, true);
                 }
                 else
@@ -185,18 +186,13 @@ namespace StayInTarkov.Coop.Player
             UnityEngine.Vector2 direction = new(playerMoveStruct.dX, playerMoveStruct.dY);
             float spd = playerMoveStruct.spd;
 
-            playerReplicatedComponent.ReplicatedMovementSpeed = spd;
-            //playerReplicatedComponent.ReplicatedDirection = null;
-
             player.InputDirection = direction;
             player.MovementContext.MovementDirection = direction;
 
+            playerReplicatedComponent.ReplicatedMovementSpeed = spd;
             player.MovementContext.CharacterMovementSpeed = spd;
 
-            player.CurrentManagedState.Move(direction);
-
-            //playerReplicatedComponent.ReplicatedDirection = direction;
-
+            //player.CurrentManagedState.Move(direction);
         }
     }
 }


### PR DESCRIPTION
Gone through the entire movement / rotation / sprinting logic. It was a mess of many ways to achieve it and it was fighting with each other. This PR does the following:

- Fixes Skipping / Sliding whilst running. However, whilst this is fixed, the player may be looking one direction whilst running in a different direction.
- Fixes animation speeds for most scenarios. People will no longer be running animation which what looked like 2x speeds.
- Fixes issue where inertia was being ignored for Clients causing a stutter in movement whilst moving side to side