### PR TITLE
Loot management improvement

### DIFF
--- a/Source/Coop/CoopPatches.cs
+++ b/Source/Coop/CoopPatches.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx.Logging;
+using StayInTarkov.Coop.Session;
 using StayInTarkov.Coop.ItemControllerPatches;
 using StayInTarkov.Coop.LocalGame;
 using StayInTarkov.Coop.Matchmaker;

--- a/Source/Coop/CoopPatches.cs
+++ b/Source/Coop/CoopPatches.cs
@@ -44,6 +44,7 @@ namespace StayInTarkov.Coop
             new NonWaveSpawnScenarioPatch(m_Config).Enable();
             new WaveSpawnScenarioPatch(m_Config).Enable();
             new LocalGame_Weather_Patch().Enable();
+            new LoadLocationLootPatch().Enable();
 
 
             // ------ MATCHMAKER -------------------------

--- a/Source/Coop/LocalGame/LoadLocationLoot_Patch.cs
+++ b/Source/Coop/LocalGame/LoadLocationLoot_Patch.cs
@@ -1,0 +1,64 @@
+﻿using Aki.Custom.Airdrops.Models;
+using EFT;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StayInTarkov.Coop.Matchmaker;
+using StayInTarkov.Networking;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.Networking.Match;
+using UnityEngine.Profiling;
+
+namespace StayInTarkov.Coop.LocalGame
+{
+    public class LocationRequest()
+    {
+        [JsonProperty("data")]
+        public LocationSettings.Location data { get; set; }
+    }
+
+    public class LoadLocationLootPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var method = ReflectionHelpers.GetMethodForType(typeof(Session4), "LoadLocationLoot");
+
+            Logger.LogDebug($"{this.GetType().Name} Method: {method?.Name}");
+
+            return method;
+        }
+        
+        [PatchPrefix]
+        private static bool PatchPrefix(string locationId, int variantId, ref Task<LocationSettings.Location> __result)
+        {
+            Logger.LogDebug("LoadLocationLoot PatchPrefix");
+
+            if(MatchmakerAcceptPatches.MatchingType == EMatchmakerType.Single)
+            {
+                return true;
+            }
+
+            string serverId = MatchmakerAcceptPatches.GetGroupId();
+
+            var objectToSend = new Dictionary<string, object>
+            {
+                { "locationId", locationId }
+                , { "variantId", variantId }
+                , { "serverId", serverId }
+            };
+
+            __result = Task.Run(() =>
+            {
+                var result = AkiBackendCommunication.Instance.PostJson($"/coop/location/getLoot", JsonConvert.SerializeObject(objectToSend));
+                result.TrySITParseJson(out LocationRequest LocationRequest);
+                return LocationRequest.data;
+            });
+
+            return false;
+        }
+    }
+}

--- a/Source/Coop/Session/LoadLocationLoot_Patch.cs
+++ b/Source/Coop/Session/LoadLocationLoot_Patch.cs
@@ -13,12 +13,12 @@ using System.Threading.Tasks;
 using UnityEngine.Networking.Match;
 using UnityEngine.Profiling;
 
-namespace StayInTarkov.Coop.LocalGame
+namespace StayInTarkov.Coop.Session
 {
-    public class LocationRequest()
+    public class LocationDataRequest()
     {
         [JsonProperty("data")]
-        public LocationSettings.Location data { get; set; }
+        public LocationSettings.Location Data { get; set; }
     }
 
     public class LoadLocationLootPatch : ModulePatch
@@ -27,17 +27,17 @@ namespace StayInTarkov.Coop.LocalGame
         {
             var method = ReflectionHelpers.GetMethodForType(typeof(Session4), "LoadLocationLoot");
 
-            Logger.LogDebug($"{this.GetType().Name} Method: {method?.Name}");
+            Logger.LogDebug($"{GetType().Name} Method: {method?.Name}");
 
             return method;
         }
-        
+
         [PatchPrefix]
         private static bool PatchPrefix(string locationId, int variantId, ref Task<LocationSettings.Location> __result)
         {
             Logger.LogDebug("LoadLocationLoot PatchPrefix");
 
-            if(MatchmakerAcceptPatches.MatchingType == EMatchmakerType.Single)
+            if (MatchmakerAcceptPatches.MatchingType == EMatchmakerType.Single)
             {
                 return true;
             }
@@ -54,8 +54,8 @@ namespace StayInTarkov.Coop.LocalGame
             __result = Task.Run(() =>
             {
                 var result = AkiBackendCommunication.Instance.PostJson($"/coop/location/getLoot", JsonConvert.SerializeObject(objectToSend));
-                result.TrySITParseJson(out LocationRequest LocationRequest);
-                return LocationRequest.data;
+                result.TrySITParseJson(out LocationDataRequest locationDataRequest);
+                return locationDataRequest.Data;
             });
 
             return false;


### PR DESCRIPTION
Added a patch on LoadLocationLoot in order to redirect the request to /coop/location/getLoot instead of /client/location/getLocalloot when connecting to a coop raid. This way, we can pass the Server Id to the server so it can provide the coop raid loot data to EFT.

Single player sessions will continue to use the default route which is /client/location/getLocalloot.

This requires the StayInTarkov.SIT.Aki-Server-Mod PR "fix-loot" to work properly.

A lot of testing was done to ensure it is working properly, but I recommend more testing to be safe.