### PR TITLE
Change Feed to off by default, Change default GC threshold

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -58,7 +58,7 @@ namespace StayInTarkov.Configuration
                 ("Advanced", "UseSITGarbageCollector", true, new ConfigDescription("Whether to use the Garbage Collector developed in to SIT OR leave it to BSG/Unity")).Value;
 
                 SITGCMemoryThreshold = StayInTarkovPlugin.Instance.Config.Bind
-                ("Advanced", "SITGarbageCollectorMemoryThreshold", 512, new ConfigDescription("The SIT Garbage Collector memory threshold (in megabytes) between ticks before forcing a garbage collection")).Value;
+                ("Advanced", "SITGarbageCollectorMemoryThreshold", 1024, new ConfigDescription("The SIT Garbage Collector memory threshold (in megabytes) between ticks before forcing a garbage collection")).Value;
 
                 SITGCClearAssets = StayInTarkovPlugin.Instance.Config.Bind
                 ("Advanced", "SITGarbageCollectorClearAssets", false, new ConfigDescription("Set SIT Garbage Collector to clear Unity assets. Reduces RAM usage but can be unstable!")).Value;

--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -98,7 +98,7 @@ namespace StayInTarkov.Configuration
 
             public int SETTING_PlayerStateTickRateInMS { get; set; } = 333;
             public bool SETTING_HeadshotsAlwaysKill { get; set; } = false;
-            public bool SETTING_ShowFeed { get; set; } = true;
+            public bool SETTING_ShowFeed { get; set; } = false;
             public bool SETTING_ShowSITStatistics { get; set; } = true;
             public int SITWebSocketPort { get; set; } = 6970;
 


### PR DESCRIPTION
The feed is a non tarkov feature that doesn't make sense to be on by default.

512 is too low of a threshold considering the minimum requirements for tarkov is 8GB. 1024 makes more sense. 