### PR TITLE
fix coop game close (exit raid)

### DIFF
--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -955,8 +955,6 @@ namespace StayInTarkov.Coop
 
         public override void Stop(string profileId, ExitStatus exitStatus, string exitName, float delay = 0f)
         {
-            Status = GameStatus.Stopped;
-
             Logger.LogInfo("CoopGame.Stop");
 
             // Notify that I have left the Server


### PR DESCRIPTION
Removed this line because:
- It makes the function Stop from derived class BaseLocalGame return prematurely because it checks if Status = GameStatus.Stopped.
- The Status is already handled in the Stop function, so we don't need to set it.

This fixes being unable to exit the raid.