### PR TITLE
Minor general fixes 2

### DIFF
--- a/Source/Coop/Components/ActionPacketHandlerComponent.cs
+++ b/Source/Coop/Components/ActionPacketHandlerComponent.cs
@@ -22,7 +22,7 @@ namespace StayInTarkov.Coop.Components
         public BlockingCollection<Dictionary<string, object>> ActionPackets { get; } = new(9999);
         public BlockingCollection<Dictionary<string, object>> ActionPacketsMovement { get; private set; } = new(9999);
         public BlockingCollection<Dictionary<string, object>> ActionPacketsDamage { get; private set; } = new(9999);
-        public ConcurrentDictionary<string, EFT.Player> Players => CoopGameComponent.Players;
+        public ConcurrentDictionary<string, CoopPlayer> Players => CoopGameComponent.Players;
         public ManualLogSource Logger { get; private set; }
 
         private List<string> RemovedFromAIPlayers = new();

--- a/Source/Coop/Components/ActionPacketHandlerComponent.cs
+++ b/Source/Coop/Components/ActionPacketHandlerComponent.cs
@@ -19,7 +19,7 @@ namespace StayInTarkov.Coop.Components
 {
     public class ActionPacketHandlerComponent : MonoBehaviour
     {
-        public BlockingCollection<Dictionary<string, object>> ActionPackets { get; } = new(9999);
+        public readonly BlockingCollection<Dictionary<string, object>> ActionPackets = new(9999);
         public BlockingCollection<Dictionary<string, object>> ActionPacketsMovement { get; private set; } = new(9999);
         public BlockingCollection<Dictionary<string, object>> ActionPacketsDamage { get; private set; } = new(9999);
         public ConcurrentDictionary<string, CoopPlayer> Players => CoopGameComponent.Players;

--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -469,7 +469,9 @@ namespace StayInTarkov.Coop
                     quitState = EQuitState.YouHaveExtractedOnlyAsHost;
             }
 
-            if (numberOfPlayersAlive == numberOfPlayersExtracted || PlayerUsers.Count() == numberOfPlayersExtracted)
+            // If there are any players alive. Number of players Alive Equals Numbers of players Extracted
+            // OR Number of Players Equals Number of players Extracted 
+            if ((numberOfPlayersAlive > 0 && numberOfPlayersAlive == numberOfPlayersExtracted) || PlayerUsers.Count() == numberOfPlayersExtracted)
             {
                 quitState = EQuitState.YourTeamHasExtracted;
             }

--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -1163,6 +1163,20 @@ namespace StayInTarkov.Coop
 
         private void CreatePlayerStatePacketFromPRC(ref JArray playerStates, EFT.Player player, PlayerReplicatedComponent prc)
         {
+            Dictionary<string, object> playerHCSync = new();
+            if (player.HealthController.IsAlive)
+            {
+                foreach (EBodyPart bodyPart in Enum.GetValues(typeof(EBodyPart)))
+                {
+                    if (bodyPart == EBodyPart.Common)
+                        continue;
+
+                    var health = player.HealthController.GetBodyPartHealth(bodyPart);
+                    playerHCSync.Add($"{bodyPart}c", health.Current);
+                    playerHCSync.Add($"{bodyPart}m", health.Maximum);
+                }
+            }
+
             PlayerStatePacket playerStatePacket = new PlayerStatePacket(
                 player.ProfileId
                 , player.Position
@@ -1178,8 +1192,12 @@ namespace StayInTarkov.Coop
                 , player.MovementContext.PoseLevel
                 , player.MovementContext.IsSprintEnabled
                 , player.InputDirection
-                );
+                , player.ActiveHealthController != null ? player.ActiveHealthController.Energy.Current : 0
+                , player.ActiveHealthController != null ? player.ActiveHealthController.Hydration.Current : 0
+                , playerHCSync.SITToJson()
+                );;
             ;
+            playerHCSync = null;
             playerStates.Add(playerStatePacket.Serialize());
 
             //Dictionary<string, object> dictPlayerState = new();

--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -44,7 +44,7 @@ namespace StayInTarkov.Coop
         /// <summary>
         /// ProfileId to Player instance
         /// </summary>
-        public ConcurrentDictionary<string, EFT.Player> Players { get; } = new();
+        public ConcurrentDictionary<string, CoopPlayer> Players { get; } = new();
 
         //public EFT.Player[] PlayerUsers
         public IEnumerable<EFT.Player> PlayerUsers
@@ -177,7 +177,7 @@ namespace StayInTarkov.Coop
             OwnPlayer = (LocalPlayer)Singleton<GameWorld>.Instance.MainPlayer;
 
             // Add own Player to Players list
-            Players.TryAdd(OwnPlayer.ProfileId, OwnPlayer);
+            Players.TryAdd(OwnPlayer.ProfileId, (CoopPlayer)OwnPlayer);
 
             // Instantiate the Requesting Object for Aki Communication
             RequestingObj = AkiBackendCommunication.GetRequestInstance(false, Logger);
@@ -1026,7 +1026,7 @@ namespace StayInTarkov.Coop
             // ----------------------------------------------------------------------------------------------------
             // Add the player to the custom Players list
             if (!Players.ContainsKey(profile.ProfileId))
-                Players.TryAdd(profile.ProfileId, otherPlayer);
+                Players.TryAdd(profile.ProfileId, (CoopPlayer)otherPlayer);
 
             if (!Singleton<GameWorld>.Instance.RegisteredPlayers.Any(x => x.Profile.ProfileId == profile.ProfileId))
                 Singleton<GameWorld>.Instance.RegisteredPlayers.Add(otherPlayer);

--- a/Source/Coop/Components/PlayerReplicatedComponent.cs
+++ b/Source/Coop/Components/PlayerReplicatedComponent.cs
@@ -239,20 +239,23 @@ namespace StayInTarkov.Core.Player
             }
 
             // Process Prone
-            bool prone = ReplicatedPlayerStatePacket.IsProne;
-            if (!player.IsInPronePose)
+            if (ReplicatedPlayerStatePacket != null)
             {
-                if (prone)
+                bool prone = ReplicatedPlayerStatePacket.IsProne;
+                if (!player.IsInPronePose)
                 {
-                    player.CurrentManagedState.Prone();
+                    if (prone)
+                    {
+                        player.CurrentManagedState.Prone();
+                    }
                 }
-            }
-            else
-            {
-                if (!prone)
+                else
                 {
-                    player.ToggleProne();
-                    player.MovementContext.UpdatePoseAfterProne();
+                    if (!prone)
+                    {
+                        player.ToggleProne();
+                        player.MovementContext.UpdatePoseAfterProne();
+                    }
                 }
             }
         }

--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -335,7 +335,7 @@ namespace StayInTarkov.Coop
             }
         }
 
-        public Dictionary<string, EFT.Player> Bots { get; set; } = new Dictionary<string, EFT.Player>();
+        public Dictionary<string, EFT.Player> Bots { get; } = new ();
 
         private async Task<LocalPlayer> CreatePhysicalBot(Profile profile, Vector3 position)
         {
@@ -343,8 +343,18 @@ namespace StayInTarkov.Coop
                 return null;
 
             if (Bots != null && Bots.Count(x => x.Value != null && x.Value.PlayerHealthController.IsAlive) >= MaxBotCount)
+            {
+                Logger.LogDebug("Block spawn of Bot. Max Bot Count has been reached!");
                 return null;
+            }
 
+            if (GameDateTime.Calculate().TimeOfDay < new TimeSpan(20, 0, 0) && profile.Info != null && profile.Info.Settings != null
+                && (profile.Info.Settings.Role == WildSpawnType.sectantPriest || profile.Info.Settings.Role == WildSpawnType.sectantWarrior)
+                )
+            {
+                Logger.LogDebug("Block spawn of Sectant (Cultist) in day time!");
+                return null;
+            }
             Logger.LogDebug($"CreatePhysicalBot: {profile.ProfileId}");
 
             LocalPlayer localPlayer;
@@ -363,7 +373,6 @@ namespace StayInTarkov.Coop
 
                 localPlayer
                    = (await CoopPlayer.Create(
-                       //= (await LocalPlayer.Create(
                        num
                        , position
                        , Quaternion.identity
@@ -376,10 +385,10 @@ namespace StayInTarkov.Coop
                        , EFT.Player.EUpdateMode.Manual
                        , EFT.Player.EUpdateMode.Auto
                        , BackendConfigManager.Config.CharacterController.BotPlayerMode
-                   , () => 1f
-                   , () => 1f
-, FilterCustomizationClass1.Default
-)
+                    , () => 1f
+                    , () => 1f
+                    , FilterCustomizationClass1.Default
+                    )
                   );
                 localPlayer.Location = base.Location_0.Id;
                 if (this.Bots.ContainsKey(localPlayer.ProfileId))

--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -955,7 +955,7 @@ namespace StayInTarkov.Coop
 
         public override void Stop(string profileId, ExitStatus exitStatus, string exitName, float delay = 0f)
         {
-            Status = GameStatus.Stopped;
+            //Status = GameStatus.Stopped;
 
             Logger.LogInfo("CoopGame.Stop");
 
@@ -982,7 +982,6 @@ namespace StayInTarkov.Coop
                 }
             }
 
-            CoopPatches.LeftGameDestroyEverything();
 
             if (this.BossWaveManager != null)
                 this.BossWaveManager.Stop();
@@ -993,10 +992,10 @@ namespace StayInTarkov.Coop
             if (this.wavesSpawnScenario_0 != null)
                 this.wavesSpawnScenario_0.Stop();
 
-            // @konstantin90s suggestion to disable patches as the game closes
-            CoopPatches.EnableDisablePatches();
 
+            CoopPatches.EnableDisablePatches();
             base.Stop(profileId, exitStatus, exitName, delay);
+            CoopPatches.LeftGameDestroyEverything();
         }
 
         public override void CleanUp()

--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -342,9 +342,10 @@ namespace StayInTarkov.Coop
             if (MatchmakerAcceptPatches.IsClient)
                 return null;
 
-            Logger.LogDebug($"CreatePhysicalBot: {profile.ProfileId}");
             if (Bots != null && Bots.Count(x => x.Value != null && x.Value.PlayerHealthController.IsAlive) >= MaxBotCount)
                 return null;
+
+            Logger.LogDebug($"CreatePhysicalBot: {profile.ProfileId}");
 
             LocalPlayer localPlayer;
             if (!base.Status.IsRunned())
@@ -729,7 +730,7 @@ namespace StayInTarkov.Coop
             };
 
             int numberOfBots = shouldSpawnBots ? MaxBotCount : 0;
-            //Logger.LogDebug($"vmethod_4: Number of Bots: {numberOfBots}");
+            Logger.LogDebug($"Max Number of Bots: {numberOfBots}");
 
             this.PBotsController.SetSettings(numberOfBots, this.BackEndSession.BackEndConfig.BotPresets, this.BackEndSession.BackEndConfig.BotWeaponScatterings);
             this.PBotsController.AddActivePLayer(this.PlayerOwner.Player);
@@ -760,10 +761,10 @@ namespace StayInTarkov.Coop
             {
                 this.BossWaveManager.Run(EBotsSpawnMode.Anyway);
 
-                if (this.nonWavesSpawnScenario_0 != null)
-                    this.nonWavesSpawnScenario_0.Run();
+                //if (this.nonWavesSpawnScenario_0 != null)
+                //    this.nonWavesSpawnScenario_0.Run();
 
-                Logger.LogDebug($"Running Wave Scenarios");
+                //Logger.LogDebug($"Running Wave Scenarios");
 
                 if (this.wavesSpawnScenario_0.SpawnWaves != null && this.wavesSpawnScenario_0.SpawnWaves.Length != 0)
                 {
@@ -802,6 +803,13 @@ namespace StayInTarkov.Coop
 
             Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<SITAirdropsManager>();
 
+            if (shouldSpawnBots)
+            {
+                if (this.nonWavesSpawnScenario_0 != null)
+                    this.nonWavesSpawnScenario_0.Run();
+
+                Logger.LogDebug($"Running Wave Scenarios");
+            }
             yield break;
         }
 

--- a/Source/Coop/CoopPlayer.cs
+++ b/Source/Coop/CoopPlayer.cs
@@ -332,7 +332,7 @@ namespace StayInTarkov.Coop
                 return;
 
             this.Rotation = rotation;
-            prc.ReplicatedRotation = rotation; 
+            //prc.ReplicatedRotation = rotation; 
 
         }
 
@@ -381,8 +381,20 @@ namespace StayInTarkov.Coop
         public override void OnDestroy()
         {
             BepInLogger.LogDebug("OnDestroy()");
+
             base.OnDestroy();
         }
 
+        public virtual void ReceivePlayerStatePacket(PlayerStatePacket playerStatePacket)
+        {
+            //Logger.LogInfo(playerStatePacket.SITToJson());
+            var prc = GetComponent<PlayerReplicatedComponent>();
+            if (prc == null || !prc.IsClientDrone)
+                return;
+
+            prc.ReplicatedPlayerStatePacket = playerStatePacket;
+
+
+        }
     }
 }

--- a/Source/Coop/ISITGame.cs
+++ b/Source/Coop/ISITGame.cs
@@ -15,6 +15,6 @@ namespace StayInTarkov.Coop
 
         public void Stop(string profileId, ExitStatus exitStatus, string exitName, float delay = 0f);
 
-        GameStatus Status { get; }
+        //GameStatus Status { get; }
     }
 }

--- a/Source/Coop/NetworkPacket/BasePacket.cs
+++ b/Source/Coop/NetworkPacket/BasePacket.cs
@@ -94,7 +94,7 @@ namespace StayInTarkov.Coop.NetworkPacket
                     var prop = allPropsFiltered[i];
                     binaryWriter.WriteNonPrefixedString(prop.GetValue(this).ToString());
                     if (i != allPropsFiltered.Count() - 1)
-                        binaryWriter.WriteNonPrefixedString(",");
+                        binaryWriter.WriteNonPrefixedString(SerializerExtensions.SIT_SERIALIZATION_PACKET_SEPERATOR.ToString());
                 }
                 result = ((MemoryStream)binaryWriter.BaseStream).ToArray();
             }
@@ -126,7 +126,7 @@ namespace StayInTarkov.Coop.NetworkPacket
 
     public static class SerializerExtensions
     {
-        public const char SIT_SERIALIZATION_PACKET_SEPERATOR = ',';
+        public const char SIT_SERIALIZATION_PACKET_SEPERATOR = '£';
         private static Dictionary<Type, PropertyInfo[]> TypeToPropertyInfos { get; } = new();
 
         static SerializerExtensions()

--- a/Source/Coop/NetworkPacket/PlayerStatePacket.cs
+++ b/Source/Coop/NetworkPacket/PlayerStatePacket.cs
@@ -32,12 +32,16 @@ namespace StayInTarkov.Coop.NetworkPacket
         public bool StaminaExhausted { get; set; }
         public float InputDirectionX { get; set; }
         public float InputDirectionY { get; set; }
+        public float Energy { get; set; }
+        public float Hydration { get; set; }
+        public string PlayerHealthSerialized { get; set; }
 
         public PlayerStatePacket() { }
 
         public PlayerStatePacket(string profileId, Vector3 position, Vector2 rotation, Vector3 headRotation, Vector2 movementDirection,
             EPlayerState state, float tilt, int step, int animatorStateIndex, float characterMovementSpeed,
-            bool isProne, float poseLevel, bool isSprinting, Vector2 inputDirection)
+            bool isProne, float poseLevel, bool isSprinting, Vector2 inputDirection, 
+            float energy, float hydration, string playerHealthSerialized)
             : base(profileId, "PlayerState")
         {
             ProfileId = profileId;
@@ -60,6 +64,9 @@ namespace StayInTarkov.Coop.NetworkPacket
             IsSprinting = isSprinting;
             InputDirectionX = inputDirection.x; 
             InputDirectionY = inputDirection.y;
+            Energy = energy;
+            Hydration = hydration;
+            PlayerHealthSerialized = playerHealthSerialized;
         }
     }
 }

--- a/Source/Coop/PacketHandlers/ExamplePlayerPacketHandler.cs
+++ b/Source/Coop/PacketHandlers/ExamplePlayerPacketHandler.cs
@@ -11,7 +11,7 @@ namespace StayInTarkov.Coop.PacketHandlers
     internal class ExamplePlayerPacketHandler : IPlayerPacketHandlerComponent
     {
         private CoopGameComponent CoopGameComponent { get { CoopGameComponent.TryGetCoopGameComponent(out var coopGC); return coopGC; } }
-        public ConcurrentDictionary<string, EFT.Player> Players => CoopGameComponent.Players;
+        public ConcurrentDictionary<string, CoopPlayer> Players => CoopGameComponent.Players;
 
         private BepInEx.Logging.ManualLogSource Logger { get; set; }
 

--- a/Source/Coop/PacketHandlers/PlayerRotatePacketHandler.cs
+++ b/Source/Coop/PacketHandlers/PlayerRotatePacketHandler.cs
@@ -50,8 +50,8 @@ namespace StayInTarkov.Coop.PacketHandlers
                 return;
 
             var player = (Players[profileId]);
-            //if (!player.GetComponent<PlayerReplicatedComponent>().IsClientDrone)
-            //    return;
+            if (!player.GetComponent<PlayerReplicatedComponent>().IsClientDrone)
+                return;
             //Logger.LogInfo(packet.SITToJson());
 
             var x = float.Parse(packet["x"].ToString());

--- a/Source/Coop/Player/Player_Init_Coop_Patch.cs
+++ b/Source/Coop/Player/Player_Init_Coop_Patch.cs
@@ -50,7 +50,7 @@ namespace StayInTarkov.Coop.Player
             if (Singleton<GameWorld>.Instance != null)
             {
                 if (!coopGC.Players.ContainsKey(profileId))
-                    coopGC.Players.TryAdd(profileId, player);
+                    coopGC.Players.TryAdd(profileId, (CoopPlayer)player);
 
                 if (!Singleton<GameWorld>.Instance.RegisteredPlayers.Any(x => x.ProfileId == profileId))
                     Singleton<GameWorld>.Instance.RegisterPlayer(player);

--- a/Source/Coop/Player/Player_Jump_Patch.cs
+++ b/Source/Coop/Player/Player_Jump_Patch.cs
@@ -41,6 +41,7 @@ namespace StayInTarkov.Coop.Player
             BasePlayerPacket playerPacket = new(player.ProfileId, "Jump");
             var serialized = playerPacket.Serialize();
             AkiBackendCommunication.Instance.SendDataToPool(serialized);
+            playerPacket = null;
             //AkiBackendCommunication.Instance.PostDownWebSocketImmediately( serialized );
 
             //Logger.LogInfo("================================");
@@ -72,14 +73,8 @@ namespace StayInTarkov.Coop.Player
             if (HasProcessed(GetType(), player, bpp))
                 return;
 
-            try
-            {
-                player.CurrentManagedState.Jump();
-            }
-            catch (Exception e)
-            {
-                Logger.LogInfo(e);
-            }
+            player.CurrentManagedState.Jump();
+            bpp = null;
 
         }
 

--- a/Source/Coop/Player/Player_Move_Patch.cs
+++ b/Source/Coop/Player/Player_Move_Patch.cs
@@ -122,42 +122,55 @@ namespace StayInTarkov.Coop.Player
 
         public void ReplicatedMove(EFT.Player player, PlayerMovePacket playerMovePacket)
         {
-            if (player.TryGetComponent<PlayerReplicatedComponent>(out PlayerReplicatedComponent playerReplicatedComponent))
-            {
-                if (playerReplicatedComponent.IsClientDrone)
-                {
-                    if (playerMovePacket.pX != 0 && playerMovePacket.pY != 0 && playerMovePacket.pZ != 0)
-                    {
-                        //player.Teleport(new Vector3(playerMovePacket.pX, playerMovePacket.pY, playerMovePacket.pZ));
-                        var ReplicatedPosition = new Vector3(playerMovePacket.pX, playerMovePacket.pY, playerMovePacket.pZ);
-                        var replicationDistance = Vector3.Distance(ReplicatedPosition, player.Position);
-                        if (replicationDistance >= 3)
-                        {
-                            player.Teleport(ReplicatedPosition, true);
-                        }
-                        else
-                        {
-                            player.Position = Vector3.Lerp(player.Position, ReplicatedPosition, Time.deltaTime * 7);
-                        }
-                    }
+            if (!player.TryGetComponent<PlayerReplicatedComponent>(out PlayerReplicatedComponent playerReplicatedComponent))
+                return;
 
-                    UnityEngine.Vector2 direction = new(playerMovePacket.dX, playerMovePacket.dY);
-                    float spd = playerMovePacket.spd;
+            if (!playerReplicatedComponent.IsClientDrone)
+                return;
 
-                    playerReplicatedComponent.ReplicatedMovementSpeed = spd;
-                    playerReplicatedComponent.ReplicatedDirection = null;
+            ReplicatedMove(player
+                , new ReceivedPlayerMoveStruct(
+                    playerMovePacket.pX
+                    , playerMovePacket.pY
+                    , playerMovePacket.pZ
+                    , playerMovePacket.dX
+                    , playerMovePacket.dY
+                    , playerMovePacket.spd
+                    ));
+            playerMovePacket = null;
 
-                    player.InputDirection = direction;
-                    player.MovementContext.MovementDirection = direction;
+            //if (playerMovePacket.pX != 0 && playerMovePacket.pY != 0 && playerMovePacket.pZ != 0)
+            //{
+            //    //player.Teleport(new Vector3(playerMovePacket.pX, playerMovePacket.pY, playerMovePacket.pZ));
+            //    var ReplicatedPosition = new Vector3(playerMovePacket.pX, playerMovePacket.pY, playerMovePacket.pZ);
+            //    var replicationDistance = Vector3.Distance(ReplicatedPosition, player.Position);
+            //    if (replicationDistance >= 3)
+            //    {
+            //        player.Teleport(ReplicatedPosition, true);
+            //    }
+            //    else
+            //    {
+            //        player.Position = Vector3.Lerp(player.Position, ReplicatedPosition, Time.deltaTime * 7);
+            //    }
+            //}
 
-                    player.MovementContext.CharacterMovementSpeed = spd;
+            //UnityEngine.Vector2 direction = new(playerMovePacket.dX, playerMovePacket.dY);
+            //float spd = playerMovePacket.spd;
 
-                    player.CurrentManagedState.Move(direction);
+            //playerReplicatedComponent.ReplicatedMovementSpeed = spd;
+            //playerReplicatedComponent.ReplicatedDirection = null;
 
-                    playerReplicatedComponent.ReplicatedDirection = direction;
+            //player.InputDirection = direction;
+            //player.MovementContext.MovementDirection = direction;
 
-                }
-            }
+            //player.MovementContext.CharacterMovementSpeed = spd;
+
+            ////player.CurrentManagedState.Move(direction);
+
+            //playerReplicatedComponent.ReplicatedDirection = direction;
+
+            //playerReplicatedComponent = null;
+
         }
 
         public void ReplicatedMove(EFT.Player player, ReceivedPlayerMoveStruct playerMoveStruct)
@@ -186,13 +199,16 @@ namespace StayInTarkov.Coop.Player
             UnityEngine.Vector2 direction = new(playerMoveStruct.dX, playerMoveStruct.dY);
             float spd = playerMoveStruct.spd;
 
-            player.InputDirection = direction;
-            player.MovementContext.MovementDirection = direction;
+            //player.InputDirection = direction;
+            //player.MovementContext.MovementDirection = direction;
+            //player.MovementContext.PlayerAnimatorSetMovementDirection(direction);
 
-            playerReplicatedComponent.ReplicatedMovementSpeed = spd;
-            player.MovementContext.CharacterMovementSpeed = spd;
+            //playerReplicatedComponent.ReplicatedMovementSpeed = spd;
+            //player.MovementContext.CharacterMovementSpeed = spd;
 
-            //player.CurrentManagedState.Move(direction);
+            player.CurrentManagedState.Move(direction);
+
+            playerReplicatedComponent = null;
         }
     }
 }

--- a/Source/Health/HealthListener.cs
+++ b/Source/Health/HealthListener.cs
@@ -75,36 +75,38 @@ namespace StayInTarkov.Health
             SetCurrentHealth(MyHealthController, CurrentHealth.Health, EBodyPart.LeftLeg);
             SetCurrentHealth(MyHealthController, CurrentHealth.Health, EBodyPart.RightLeg);
 
-            SetCurrent("Energy");
-            SetCurrent("Hydration");
+            SetCurrent(MyHealthController, CurrentHealth, "Energy");
+            SetCurrent(MyHealthController, CurrentHealth, "Hydration");
 
             AkiBackendCommunication.Instance.PostJson("/player/health/sync", Instance.CurrentHealth.ToJson());
         }
 
-        private void SetCurrent(string v)
+        public static void SetCurrent(object healthController, PlayerHealth currentHealth, string v)
         {
             //PatchConstants.Logger.LogInfo("HealthListener:SetCurrent:" + v);
 
-            if (ReflectionHelpers.GetAllPropertiesForObject(MyHealthController).Any(x => x.Name == v))
+            if (ReflectionHelpers.GetAllPropertiesForObject(healthController).Any(x => x.Name == v))
             {
-                var valuestruct = ReflectionHelpers.GetAllPropertiesForObject(MyHealthController).FirstOrDefault(x => x.Name == v).GetValue(MyHealthController);
+                var valuestruct = ReflectionHelpers.GetAllPropertiesForObject(healthController).FirstOrDefault(x => x.Name == v).GetValue(healthController);
                 if (valuestruct == null)
                     return;
 
                 var currentAmount = ReflectionHelpers.GetAllFieldsForObject(valuestruct).FirstOrDefault(x => x.Name == "Current").GetValue(valuestruct);
                 //PatchConstants.Logger.LogInfo(currentAmount);
-                CurrentHealth.GetType().GetProperty(v).SetValue(CurrentHealth, float.Parse(currentAmount.ToString()));
+                if(currentHealth != null)
+                    currentHealth.GetType().GetProperty(v).SetValue(currentHealth, float.Parse(currentAmount.ToString()));
             }
-            else if (ReflectionHelpers.GetAllFieldsForObject(MyHealthController).Any(x => x.Name == v))
+            else if (ReflectionHelpers.GetAllFieldsForObject(healthController).Any(x => x.Name == v))
             {
-                var valuestruct = ReflectionHelpers.GetAllFieldsForObject(MyHealthController).FirstOrDefault(x => x.Name == v).GetValue(MyHealthController);
+                var valuestruct = ReflectionHelpers.GetAllFieldsForObject(healthController).FirstOrDefault(x => x.Name == v).GetValue(healthController);
                 if (valuestruct == null)
                     return;
 
                 var currentAmount = ReflectionHelpers.GetAllFieldsForObject(valuestruct).FirstOrDefault(x => x.Name == "Current").GetValue(valuestruct);
                 //PatchConstants.Logger.LogInfo(currentAmount);
 
-                CurrentHealth.GetType().GetProperty(v).SetValue(CurrentHealth, float.Parse(currentAmount.ToString()));
+                if(currentHealth != null)
+                    currentHealth.GetType().GetProperty(v).SetValue(currentHealth, float.Parse(currentAmount.ToString()));
             }
 
         }

--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -26,6 +26,8 @@ namespace StayInTarkov.Networking
     {
         public const int DEFAULT_TIMEOUT_MS = 5000;
         public const int DEFAULT_TIMEOUT_LONG_MS = 9999;
+        public const string PACKET_TAG_METHOD = "m";
+        public const string PACKET_TAG_DATA = "data";
 
         private string m_Session;
 
@@ -207,45 +209,32 @@ namespace StayInTarkov.Networking
         private void WebSocket_OnMessage(object sender, WebSocketSharp.MessageEventArgs e)
         {
             GC.AddMemoryPressure(e.RawData.Length);
+
+            if (e == null)
+                return;
+
+            if (string.IsNullOrEmpty(e.Data))
+                return;
+
+            ProcessPacketBytes(e.RawData);
+            GC.RemoveMemoryPressure(e.RawData.Length);
+
+        }
+
+        private void ProcessPacketBytes(byte[] data)
+        {
             try
             {
-                //Logger.LogInfo($"Step.0. WebSocket_OnMessage");
-
-                if (sender == null)
+                if (data == null)
                     return;
 
-                if (e == null)
-                    return;
-
-                if (string.IsNullOrEmpty(e.Data))
-                    return;
-
-                if (e.RawData == null)
-                    return;
-
-                if (e.RawData.Length == 0)
+                if (data.Length == 0)
                     return;
 
                 Dictionary<string, object> packet = null;
-                if (e.Data.IndexOf("{") > 0)
-                    return;
-
-                if (!e.Data.EndsWith("}"))
-                    return;
-
-
-                //if (WebSocketPreviousReceived.Contains(e.Data))
-                //    return;
-
-                //WebSocketPreviousReceived.Add(e.Data);
-
-                if (DEBUGPACKETS)
-                {
-                    Logger.LogInfo(e.Data);
-                }
-
+               
                 // Use StreamReader & JsonTextReader to improve memory / cpu usage
-                using (var streamReader = new StreamReader(new MemoryStream(e.RawData)))
+                using (var streamReader = new StreamReader(new MemoryStream(data)))
                 {
                     using (var reader = new JsonTextReader(streamReader))
                     {
@@ -254,14 +243,18 @@ namespace StayInTarkov.Networking
                     }
                 }
 
-                if (!CoopGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                    return;
+                var coopGameComponent = CoopGameComponent.GetCoopGameComponent();
 
                 if (coopGameComponent == null)
                     return;
 
                 if (packet == null)
                     return;
+
+                if (DEBUGPACKETS)
+                {
+                    Logger.LogInfo(packet.SITToJson());
+                }
 
                 //Logger.LogDebug($"Step.1. Packet exists. {packet.ToJson()}");
 
@@ -291,7 +284,6 @@ namespace StayInTarkov.Networking
                 {
                     if (Singleton<ISITGame>.Instantiated && !Singleton<ISITGame>.Instance.ExtractedPlayers.Contains(packet["profileId"].ToString()))
                     {
-                        Logger.LogInfo(e.Data);
                         Singleton<ISITGame>.Instance.ExtractedPlayers.Add(packet["profileId"].ToString());
                     }
                     return;
@@ -308,33 +300,20 @@ namespace StayInTarkov.Networking
                     return;
                 }
 
-                // If this is a SIT serialization packet
-                if (packet.ContainsKey("data") && packet.ContainsKey("m"))
-                {
-                    var data = packet["data"];
-                    if (data == null)
-                        return;
-                    //Logger.LogInfo(" =============WebSocket_OnMessage========= ");
-                    //Logger.LogInfo(" ==================SIT Packet============= ");
-                    //Logger.LogInfo(packet.ToJson());
-                    //Logger.LogInfo(" ========================================= ");
-                    //if (!packet.ContainsKey("accountId"))
-                    if (!packet.ContainsKey("profileId"))
-                    {
-                        packet.Add("profileId", packet["data"].ToString().Split(',')[0]);
-                    }
-                }
+
 
                 // -------------------------------------------------------
                 // Add to the Coop Game Component Action Packets
                 if (coopGameComponent == null || coopGameComponent.ActionPackets == null || coopGameComponent.ActionPacketHandler == null)
                     return;
 
-                if (packet.ContainsKey("m")
-                    && packet["m"].ToString() == "Move")
+                ProcessSITPacket(ref packet);
+
+                if (packet.ContainsKey(PACKET_TAG_METHOD)
+                    && packet[PACKET_TAG_METHOD].ToString() == "Move")
                     coopGameComponent.ActionPacketHandler.ActionPacketsMovement.TryAdd(packet);
-                else if (packet.ContainsKey("m")
-                    && packet["m"].ToString() == "ApplyDamageInfo")
+                else if (packet.ContainsKey(PACKET_TAG_METHOD)
+                    && packet[PACKET_TAG_METHOD].ToString() == "ApplyDamageInfo")
                 {
                     coopGameComponent.ActionPacketHandler.ActionPacketsDamage.TryAdd(packet);
                 }
@@ -346,7 +325,26 @@ namespace StayInTarkov.Networking
             {
                 Logger.LogError(ex);
             }
+        }
 
+        private void ProcessSITPacket(ref Dictionary<string, object> packet)
+        {
+            // If this is a SIT serialization packet
+            if (packet.ContainsKey(PACKET_TAG_DATA) && packet.ContainsKey(PACKET_TAG_METHOD))
+            {
+                var data = packet[PACKET_TAG_DATA];
+                if (data == null)
+                    return;
+                //Logger.LogInfo(" =============WebSocket_OnMessage========= ");
+                //Logger.LogInfo(" ==================SIT Packet============= ");
+                //Logger.LogInfo(packet.ToJson());
+                //Logger.LogInfo(" ========================================= ");
+                //if (!packet.ContainsKey("accountId"))
+                if (!packet.ContainsKey("profileId"))
+                {
+                    packet.Add("profileId", packet[PACKET_TAG_DATA].ToString().Split(SerializerExtensions.SIT_SERIALIZATION_PACKET_SEPERATOR)[0]);
+                }
+            }
         }
 
         public static AkiBackendCommunication GetRequestInstance(bool createInstance = false, ManualLogSource logger = null)
@@ -665,7 +663,7 @@ namespace StayInTarkov.Networking
                             httpClient.DefaultRequestHeaders.Add("debug", "1");
                         }
                         var inputDataBytes = Encoding.UTF8.GetBytes(data);
-                        byte[] bytes = compress ? Zlib.Compress(data) : inputDataBytes;
+                        byte[] bytes = compress ? Zlib.Compress(inputDataBytes) : inputDataBytes;
                         byteContent = new ByteArrayContent(bytes);
                         byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                         if (compress)

--- a/Source/ThirdParty/Zlib.cs
+++ b/Source/ThirdParty/Zlib.cs
@@ -1,4 +1,5 @@
 using ComponentAce.Compression.Libs.zlib;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace StayInTarkov.ThirdParty
@@ -69,9 +70,21 @@ namespace StayInTarkov.ThirdParty
             return SimpleZlib.CompressToBytes(data, 6);
         }
 
-        public static async Task<byte[]> CompressAsync(string data, ZlibCompression level)
+        public static byte[] Compress(byte[] data, ZlibCompression level = ZlibCompression.Normal)
         {
-            return await Task.Run(() => Compress(data));
+            var ms = new MemoryStream();
+            using (var zs = (level > ZlibCompression.Store)
+                    ? new ZOutputStream(ms, (int)level)
+                    : new ZOutputStream(ms))
+                {
+                    zs.Write(data, 0, data.Length);
+                }
+
+            var result = ms.ToArray();
+            ms.Close();
+            ms.Dispose();
+            ms = null;
+            return result;
         }
 
         /// <summary>

--- a/Source/UI/RemoveScavModeButtonPatch.cs
+++ b/Source/UI/RemoveScavModeButtonPatch.cs
@@ -1,17 +1,15 @@
-﻿using System.Reflection;
+﻿using EFT.UI;
+using System.Reflection;
 using UnityEngine;
 
 
 namespace StayInTarkov.UI
 {
-    /// <summary>
-    /// Created by: Paulov
-    /// </summary>
     public class RemoveScavModeButtonPatch : ModulePatch
     {
         protected override MethodBase GetTargetMethod()
         {
-            return typeof(EFT.UI.Matchmaker.MatchMakerSideSelectionScreen).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance);
+            return ReflectionHelpers.GetMethodForType(typeof(EFT.UI.Matchmaker.MatchMakerSideSelectionScreen), "Awake");
         }
 
         [PatchPostfix]
@@ -26,9 +24,15 @@ namespace StayInTarkov.UI
             var pmcdesc = GameObject.Find("Description");
             pmcdesc.active = false;
 
+            Logger.LogInfo(Screen.width);
+            Logger.LogInfo(Screen.width / 2);
+
             var pmcs = GameObject.Find("PMCs");
             var mmSSC = pmcs.transform.parent.gameObject;
-            pmcs.transform.position = new Vector3(mmSSC.transform.position.x / 1.305f, pmcs.transform.position.y * 0.75f, 0);
+            Logger.LogInfo(pmcs.transform.position.x);
+            Logger.LogInfo(mmSSC.transform.position.x);
+            pmcs.transform.position = new Vector3(Screen.width * 0.39f, pmcs.transform.position.y * 0.75f, 0);
+           
         }
     }
 }

--- a/Source/UI/RemoveScavModeButtonPatch.cs
+++ b/Source/UI/RemoveScavModeButtonPatch.cs
@@ -24,15 +24,10 @@ namespace StayInTarkov.UI
             var pmcdesc = GameObject.Find("Description");
             pmcdesc.active = false;
 
-            Logger.LogInfo(Screen.width);
-            Logger.LogInfo(Screen.width / 2);
-
             var pmcs = GameObject.Find("PMCs");
             var mmSSC = pmcs.transform.parent.gameObject;
-            Logger.LogInfo(pmcs.transform.position.x);
-            Logger.LogInfo(mmSSC.transform.position.x);
-            pmcs.transform.position = new Vector3(Screen.width * 0.39f, pmcs.transform.position.y * 0.75f, 0);
-           
+            pmcs.transform.localPosition = new Vector3(-225, 500, 0);
+
         }
     }
 }


### PR DESCRIPTION
This PR does the following:

- Introduces a check to stop cultists spawning in the day
- Fix issue where User could not exit the game (GameStatus cannot be changed before BaseLocalGame.Stop)
- Fix an issue where PlayerRotate packets were round tripping and on some occassions repeating the round trip
- Fix the position of the PMC character on the "Character Select" screen
- Fix incorrect message being displayed when your team is dead
- Introduce new way of sending arrays of SIT serialized data (very performant and has very small network cost)
- Converts Player State handling from Dictionary to PlayerStatePacket using array of SIT serialized data
- Fix issue with BepInEx preloaders [New Assembly]
- Improve current movement logic to smooth it out the best it can be in its current form [Sprinting still not fixed]
- Add a Zlib Compress of Bytes method
- Refactor WebSocket_OnMessage in to several methods