### PR TITLE
Make "Proceed EmptyHands" always execute the original function

### DIFF
--- a/Source/Coop/Player/Proceed/Player_Proceed_EmptyHands_Patch.cs
+++ b/Source/Coop/Player/Proceed/Player_Proceed_EmptyHands_Patch.cs
@@ -23,7 +23,10 @@ namespace StayInTarkov.Coop.Player.Proceed
         [PatchPrefix]
         public static bool PrePatch(EFT.Player __instance)
         {
-            return CallLocally.Contains(__instance.ProfileId);
+            // Giving 'false' to the player will cause issue.
+            // return CallLocally.Contains(__instance.ProfileId);
+
+            return true;
         }
 
         [PatchPostfix]
@@ -41,6 +44,10 @@ namespace StayInTarkov.Coop.Player.Proceed
 
         public override void Replicated(EFT.Player player, Dictionary<string, object> dict)
         {
+            // The original function is always running, don't let it run again.
+            if (player.IsYourPlayer)
+                return;
+
             if (!dict.ContainsKey("data"))
                 return;
 


### PR DESCRIPTION
Fixes many issue when player is not carrying knife in the raid.
Example: Drop the weapon / grenade / knife while holding it, this will softlock the hands (busy hands bug).