### PR TITLE
Aki's SettingsLocationPatch and some fixes

### DIFF
--- a/Source/AkiSupport/Custom/SettingsLocationPatch.cs
+++ b/Source/AkiSupport/Custom/SettingsLocationPatch.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace StayInTarkov.AkiSupport.Custom
+{
+    /// <summary>
+    /// Created by: SPT-Aki team
+    /// Link: https://dev.sp-tarkov.com/SPT-AKI/Modules/src/branch/master/project/Aki.Custom/Patches/SettingsLocationPatch.cs
+    /// Modified by: dounai2333: Applying patch seems make game stop loading forever, I don't really know why, use reflection instead.
+    /// </summary>
+
+    public class SettingsLocationPatch
+    {
+        private static string _sptPath = Path.Combine(Environment.CurrentDirectory, "user", "sptSettings");
+
+        public static void Enable()
+        {
+            // Screenshot
+            FieldInfo DocumentsSettings = ReflectionHelpers.GetFieldFromType(typeof(SettingsManager), "string_0");
+
+            // Game Settings
+            FieldInfo ApplicationDataSettings = ReflectionHelpers.GetFieldFromType(typeof(SettingsManager), "string_1");
+
+            // They are 'static' variables, not needed to give a instance.
+            DocumentsSettings.SetValue(null, _sptPath);
+            ApplicationDataSettings.SetValue(null, _sptPath);
+        }
+    }
+}

--- a/Source/Coop/Components/CoopGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponent.cs
@@ -1343,9 +1343,6 @@ namespace StayInTarkov.Coop
             rectEndOfGameMessage.width = Screen.width * w;
             rectEndOfGameMessage.height = Screen.height * h;
 
-            var numberOfPlayersDead = PlayerUsers.Count(x => !x.HealthController.IsAlive);
-
-
             if (LocalGameInstance == null)
                 return;
 
@@ -1353,7 +1350,7 @@ namespace StayInTarkov.Coop
             if (coopGame == null)
                 return;
 
-            rect = DrawSITStats(rect, numberOfPlayersDead, coopGame);
+            rect = DrawSITStats(rect, coopGame);
 
             var quitState = GetQuitState();
             switch (quitState)
@@ -1435,12 +1432,13 @@ namespace StayInTarkov.Coop
             return rect;
         }
 
-        private Rect DrawSITStats(Rect rect, int numberOfPlayersDead, CoopGame coopGame)
+        private Rect DrawSITStats(Rect rect, CoopGame coopGame)
         {
             if (!PluginConfigSettings.Instance.CoopSettings.SETTING_ShowSITStatistics)
                 return rect;
 
             var numberOfPlayersAlive = PlayerUsers.Count(x => x.HealthController.IsAlive);
+            var numberOfPlayersDead = PlayerUsers.Count(x => !x.HealthController.IsAlive);
             // gathering extracted
             var numberOfPlayersExtracted = coopGame.ExtractedPlayers.Count;
             GUI.Label(rect, $"Players (Alive): {numberOfPlayersAlive}");
@@ -1498,7 +1496,7 @@ namespace StayInTarkov.Coop
                 if (pl.HealthController == null)
                     continue;
 
-                if (pl.IsYourPlayer && pl.HealthController.IsAlive)
+                if (pl.IsYourPlayer && pl.HealthController.IsAlive && pl.PointOfView == EPointOfView.FirstPerson)
                     continue;
 
                 Vector3 aboveBotHeadPos = pl.PlayerBones.Pelvis.position + (Vector3.up * (pl.HealthController.IsAlive ? 1.1f : 0.3f));

--- a/Source/Coop/Components/PlayerReplicatedComponent.cs
+++ b/Source/Coop/Components/PlayerReplicatedComponent.cs
@@ -53,40 +53,37 @@ namespace StayInTarkov.Core.Player
                 StayInTarkovHelperConstants.Logger.LogDebug($"PlayerReplicatedComponent:Start:Set Player to {player}");
             }
 
-            if (player.ProfileId.StartsWith("pmc"))
+            if (player.Side != EPlayerSide.Savage && ReflectionHelpers.GetDogtagItem(player) == null)
             {
-                if (ReflectionHelpers.GetDogtagItem(player) == null)
+                if (!CoopGameComponent.TryGetCoopGameComponent(out CoopGameComponent coopGameComponent))
+                    return;
+
+                Slot dogtagSlot = player.Inventory.Equipment.GetSlot(EquipmentSlot.Dogtag);
+                if (dogtagSlot == null)
+                    return;
+
+                string itemId = new MongoID(true);
+                Logger.LogInfo($"New Dogtag Id: {itemId}");
+                //using (SHA256 sha256 = SHA256.Create())
+                //{
+                //    StringBuilder sb = new();
+
+                //    byte[] hashes = sha256.ComputeHash(Encoding.UTF8.GetBytes(coopGameComponent.ServerId + player.ProfileId + coopGameComponent.Timestamp));
+                //    for (int i = 0; i < hashes.Length; i++)
+                //        sb.Append(hashes[i].ToString("x2"));
+
+                //    itemId = sb.ToString().Substring(0, 24);
+                //}
+
+                Item dogtag = Spawners.ItemFactory.CreateItem(itemId, player.Side == EPlayerSide.Bear ? DogtagComponent.BearDogtagsTemplate : DogtagComponent.UsecDogtagsTemplate);
+
+                if (dogtag != null)
                 {
-                    if (!CoopGameComponent.TryGetCoopGameComponent(out CoopGameComponent coopGameComponent))
+                    if (!dogtag.TryGetItemComponent(out DogtagComponent dogtagComponent))
                         return;
 
-                    Slot dogtagSlot = player.Inventory.Equipment.GetSlot(EquipmentSlot.Dogtag);
-                    if (dogtagSlot == null)
-                        return;
-
-                    string itemId = new MongoID(true);
-                    Logger.LogInfo($"New Dogtag Id: {itemId}");
-                    //using (SHA256 sha256 = SHA256.Create())
-                    //{
-                    //    StringBuilder sb = new();
-
-                    //    byte[] hashes = sha256.ComputeHash(Encoding.UTF8.GetBytes(coopGameComponent.ServerId + player.ProfileId + coopGameComponent.Timestamp));
-                    //    for (int i = 0; i < hashes.Length; i++)
-                    //        sb.Append(hashes[i].ToString("x2"));
-
-                    //    itemId = sb.ToString().Substring(0, 24);
-                    //}
-
-                    Item dogtag = Spawners.ItemFactory.CreateItem(itemId, player.Side == EPlayerSide.Bear ? DogtagComponent.BearDogtagsTemplate : DogtagComponent.UsecDogtagsTemplate);
-
-                    if (dogtag != null)
-                    {
-                        if (!dogtag.TryGetItemComponent(out DogtagComponent dogtagComponent))
-                            return;
-
-                        dogtagComponent.GroupId = player.Profile.Info.GroupId;
-                        dogtagSlot.AddWithoutRestrictions(dogtag);
-                    }
+                    dogtagComponent.GroupId = player.Profile.Info.GroupId;
+                    dogtagSlot.AddWithoutRestrictions(dogtag);
                 }
             }
 

--- a/Source/Coop/CoopInventoryController.cs
+++ b/Source/Coop/CoopInventoryController.cs
@@ -26,7 +26,7 @@ namespace StayInTarkov.Coop
         {
             BepInLogger = BepInEx.Logging.Logger.CreateLogSource(nameof(CoopInventoryController));
             this.Player = player;
-            if (profile.ProfileId.StartsWith("pmc") && !IsDiscardLimitsFine(DiscardLimits))
+            if (player.Side != EPlayerSide.Savage && !IsDiscardLimitsFine(base.DiscardLimits))
                 base.ResetDiscardLimits();
         }
 

--- a/Source/Coop/CoopInventoryControllerForClientDrone.cs
+++ b/Source/Coop/CoopInventoryControllerForClientDrone.cs
@@ -19,7 +19,7 @@ namespace StayInTarkov.Coop
         {
             BepInLogger = BepInEx.Logging.Logger.CreateLogSource(nameof(CoopInventoryControllerForClientDrone));
 
-            if (profile.ProfileId.StartsWith("pmc") && !CoopInventoryController.IsDiscardLimitsFine(DiscardLimits))
+            if (player.Side != EPlayerSide.Savage && !CoopInventoryController.IsDiscardLimitsFine(base.DiscardLimits))
                 base.ResetDiscardLimits();
         }
 

--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -339,6 +339,9 @@ namespace StayInTarkov
                 //// --------- Airdrop -----------------------
                 //new AirdropPatch().Enable();
 
+                //// --------- Settings -----------------------
+                SettingsLocationPatch.Enable();
+
                 //// --------- Screens ----------------
                 EnableSPPatches_Screens(Config);
 
@@ -350,9 +353,6 @@ namespace StayInTarkov
                 EnableSPPatches_Bots(Config);
 
                 new QTEPatch().Enable();
-
-               
-
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Added Aki Custom's SettingsLocationPatch, move the game client settings from ``C:\Users\(YourUsername)\AppData\Roaming\Battlestate Games\Escape from Tarkov\Settings`` to ``(Game directory)\user\sptSettings`` .
- - Original message from Aki: ``One concern people have playing SPT is of it altering their live files. Both SPT and live share the same config folder found in your appdata. With today's patch this is no longer the case, the majority of config settings are isolated to SPT and stored in SPT\user\sptSettings. Be aware this means the first time you start up 3.7.0 will be as if you've never played Tarkov before and default every setting.``


- When server has "showPlayerNameTags" set to true, player in the game can see their own nametag when they are in free camera mode. (In previous version, player can only see their own nametag when they are dead, so this simple fix make them see the nametag when they are alive)
- Fixes some no longer working features that checking "pmc" prefix in the ProfileId, due to Aki changed the logic in 3.8.0, these features are dead.