### PR TITLE
Aki's SettingsLocationPatch, death camera and some fixes

### DIFF
--- a/Source/AkiSupport/Custom/SettingsLocationPatch.cs
+++ b/Source/AkiSupport/Custom/SettingsLocationPatch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace StayInTarkov.AkiSupport.Custom
+{
+    /// <summary>
+    /// Created by: SPT-Aki team
+    /// Link: https://dev.sp-tarkov.com/SPT-AKI/Modules/src/branch/master/project/Aki.Custom/Patches/SettingsLocationPatch.cs
+    /// Modified by: dounai2333: Applying patch seems make game stop loading forever, I don't really know why, use reflection instead.
+    /// </summary>
+    public class SettingsLocationPatch
+    {
+        private static string _sptPath = Path.Combine(Environment.CurrentDirectory, "user", "sptSettings");
+
+        public static void Enable()
+        {
+            // Screenshot
+            FieldInfo DocumentsSettings = ReflectionHelpers.GetFieldFromType(typeof(SettingsManager), "string_0");
+
+            // Game Settings
+            FieldInfo ApplicationDataSettings = ReflectionHelpers.GetFieldFromType(typeof(SettingsManager), "string_1");
+
+            // They are 'static' variables, not needed to give a instance.
+            DocumentsSettings.SetValue(null, _sptPath);
+            ApplicationDataSettings.SetValue(null, _sptPath);
+        }
+    }
+}

--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -118,7 +118,7 @@ namespace StayInTarkov.Configuration
                 get
                 {
                     return StayInTarkovPlugin.Instance.Config.Bind
-                       ("Coop", "BlackScreenOnDeathTime", 333, new ConfigDescription("How long to wait until your death waits to become a Free Camera")).Value;
+                       ("Coop", "BlackScreenOnDeathTime", 500, new ConfigDescription("How long to wait until your death waits to become a Free Camera")).Value;
                 }
             }
 

--- a/Source/Coop/Components/CoopGameComponents/CoopGameGUIComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/CoopGameGUIComponent.cs
@@ -89,9 +89,6 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             rectEndOfGameMessage.width = Screen.width * w;
             rectEndOfGameMessage.height = Screen.height * h;
 
-            var numberOfPlayersDead = PlayerUsers.Count(x => !x.HealthController.IsAlive);
-
-
             if (LocalGameInstance == null)
                 return;
 
@@ -99,7 +96,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             if (coopGame == null)
                 return;
 
-            rect = DrawSITStats(rect, numberOfPlayersDead, coopGame);
+            rect = DrawSITStats(rect, coopGame);
 
             var quitState = CoopGameComponent.GetQuitState();
             switch (quitState)
@@ -162,12 +159,13 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             return rect;
         }
 
-        private Rect DrawSITStats(Rect rect, int numberOfPlayersDead, CoopGame coopGame)
+        private Rect DrawSITStats(Rect rect, CoopGame coopGame)
         {
             if (!PluginConfigSettings.Instance.CoopSettings.SETTING_ShowSITStatistics)
                 return rect;
 
             var numberOfPlayersAlive = PlayerUsers.Count(x => x.HealthController.IsAlive);
+            var numberOfPlayersDead = PlayerUsers.Count(x => !x.HealthController.IsAlive);
             // gathering extracted
             var numberOfPlayersExtracted = coopGame.ExtractedPlayers.Count;
             GUI.Label(rect, $"Players (Alive): {numberOfPlayersAlive}");
@@ -225,7 +223,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                 if (pl.HealthController == null)
                     continue;
 
-                if (pl.IsYourPlayer && pl.HealthController.IsAlive)
+                if (pl.IsYourPlayer && pl.HealthController.IsAlive && pl.PointOfView == EPointOfView.FirstPerson)
                     continue;
 
                 Vector3 aboveBotHeadPos = pl.PlayerBones.Pelvis.position + Vector3.up * (pl.HealthController.IsAlive ? 1.1f : 0.3f);

--- a/Source/Coop/Controllers/CoopInventoryController.cs
+++ b/Source/Coop/Controllers/CoopInventoryController.cs
@@ -26,7 +26,7 @@ namespace StayInTarkov.Coop.Controllers
         {
             BepInLogger = BepInEx.Logging.Logger.CreateLogSource(nameof(CoopInventoryController));
             Player = player;
-            if (profile.ProfileId.StartsWith("pmc") && !IsDiscardLimitsFine(DiscardLimits))
+            if (player.Side != EPlayerSide.Savage && !IsDiscardLimitsFine(DiscardLimits))
                 ResetDiscardLimits();
         }
 

--- a/Source/Coop/Controllers/CoopInventoryControllerForClientDrone.cs
+++ b/Source/Coop/Controllers/CoopInventoryControllerForClientDrone.cs
@@ -19,7 +19,7 @@ namespace StayInTarkov.Coop.Controllers
         {
             BepInLogger = BepInEx.Logging.Logger.CreateLogSource(nameof(CoopInventoryControllerForClientDrone));
 
-            if (profile.ProfileId.StartsWith("pmc") && !CoopInventoryController.IsDiscardLimitsFine(DiscardLimits))
+            if (player.Side != EPlayerSide.Savage && !CoopInventoryController.IsDiscardLimitsFine(DiscardLimits))
                 ResetDiscardLimits();
         }
 

--- a/Source/Coop/FreeCamera/FreeCameraController.cs
+++ b/Source/Coop/FreeCamera/FreeCameraController.cs
@@ -1,4 +1,5 @@
-﻿using Comfort.Common;
+﻿using BSG.CameraEffects;
+using Comfort.Common;
 using EFT;
 using EFT.CameraControl;
 using EFT.UI;
@@ -65,7 +66,6 @@ namespace StayInTarkov.Coop.FreeCamera
 
         int DeadTime = 0;
 
-
         public void Update()
         {
             if (_gamePlayerOwner == null)
@@ -86,117 +86,63 @@ namespace StayInTarkov.Coop.FreeCamera
 
             var quitState = coopGC.GetQuitState();
 
-            if (
-                (
-                Input.GetKey(KeyCode.F9)
-                ||
-                ((quitState != CoopGameComponent.EQuitState.NONE) && !_freeCamScript.IsActive)
-                )
-                && _lastTime < DateTime.Now.AddSeconds(-3)
-            )
+            if (_gamePlayerOwner.Player.PlayerHealthController.IsAlive
+                && (Input.GetKey(KeyCode.F9) || (quitState != CoopGameComponent.EQuitState.NONE && !_freeCamScript.IsActive))
+                && _lastTime < DateTime.Now.AddSeconds(-3))
             {
                 _lastTime = DateTime.Now;
-
-                if (quitState != CoopGameComponent.EQuitState.YouAreDead)
-                {
-                    ToggleCamera();
-                    ToggleUi();
-                }
-                else if (DeadTime > PluginConfigSettings.Instance.CoopSettings.BlackScreenOnDeathTime && quitState == CoopGameComponent.EQuitState.YouAreDead)
-                {
-                    ToggleCamera();
-                    ToggleUi();
-                }
+                ToggleCamera();
+                ToggleUi();
             }
 
             if (!_gamePlayerOwner.Player.PlayerHealthController.IsAlive)
             {
-                DeadTime++;
-            }
-
-            // Player is dead. Remove all effects!
-            if (!_gamePlayerOwner.Player.PlayerHealthController.IsAlive && _freeCamScript.IsActive)
-            {
-                var fpsCamInstance = FPSCamera.Instance;
-                if (fpsCamInstance == null)
+                // This is to make sure the screen effect remove code only get executed once, instead of running every frame.
+                if (DeadTime == -1)
                     return;
 
-                if (fpsCamInstance.EffectsController == null)
-                    return;
-
-                // Death Fade (the blink to death). Don't show this as we want to continue playing after death!
-                var deathFade = fpsCamInstance.EffectsController.GetComponent<DeathFade>();
-                if (DeadTime > PluginConfigSettings.Instance.CoopSettings.BlackScreenOnDeathTime)
+                if (DeadTime < PluginConfigSettings.Instance.CoopSettings.BlackScreenOnDeathTime)
                 {
-                    if (deathFade != null)
-                    {
-                        // Delete DeathFade
-                        deathFade.enabled = false;
-                        GameObject.Destroy(deathFade);
+                    DeadTime++;
+                }
+                else
+                {
+                    DeadTime = -1;
 
-                        // Toggle the Camera
-                        ToggleCamera();
-                        ToggleUi();
-                    }
+                    var fpsCamInstance = FPSCamera.Instance;
+                    if (fpsCamInstance == null)
+                        return;
 
-                    // Fast Blur. Don't show this as we want to continue playing after death!
-                    var fastBlur = fpsCamInstance.EffectsController.GetComponent<FastBlur>();
-                    if (fastBlur != null)
-                    {
-                        fastBlur.enabled = false;
-                    }
+                    // Reset FOV after died
+                    if (fpsCamInstance.Camera != null)
+                        fpsCamInstance.Camera.fieldOfView = Singleton<SettingsManager>.Instance.Game.Settings.FieldOfView;
 
-                    var eyeBurn = fpsCamInstance.EffectsController.GetComponent<EyeBurn>();
-                    if (eyeBurn != null)
-                    {
-                        eyeBurn.enabled = false;
-                    }
+                    var effectsController = fpsCamInstance.EffectsController;
+                    if (effectsController == null)
+                        return;
 
-                    var ccWiggle = fpsCamInstance.EffectsController.GetComponent<CC_Wiggle>();
-                    if (ccWiggle != null)
-                    {
-                        ccWiggle.enabled = false;
-                    }
-
-                    var ccBlur = fpsCamInstance.EffectsController.GetComponent<CC_RadialBlur>();
-                    if (ccBlur != null)
-                    {
-                        ccBlur.enabled = false;
-                    }
-
-                    var mBlur = fpsCamInstance.EffectsController.GetComponent<MotionBlur>();
-                    if (mBlur != null)
-                    {
-                        mBlur.enabled = false;
-                    }
+                    DisableAndDestroyEffect(effectsController.GetComponent<DeathFade>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<FastBlur>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<EyeBurn>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<TextureMask>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<CC_Wiggle>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<CC_RadialBlur>());
+                    DisableAndDestroyEffect(effectsController.GetComponent<MotionBlur>());
 
                     var ccBlends = fpsCamInstance.EffectsController.GetComponents<CC_Blend>();
                     if (ccBlends != null)
-                    {
-                        foreach (var b in ccBlends) 
-                        {
-                            b.enabled = false;
-                        }
-                    }
+                        foreach (var ccBlend in ccBlends)
+                            DisableAndDestroyEffect(ccBlend);
 
-                    var visor = fpsCamInstance.VisorEffect;
-                    if (fastBlur != null)
-                    {
-                        visor.enabled = false;
-                    }
-                    var night = fpsCamInstance.NightVision;
-                    if (night != null)
-                    {
-                        night.enabled = false;
-                    }
-                    var thermal = fpsCamInstance.ThermalVision;
-                    if (thermal != null)
-                    {
-                        thermal.enabled = false;
-                    }
+                    DisableAndDestroyEffect(fpsCamInstance.VisorEffect);
+                    DisableAndDestroyEffect(fpsCamInstance.NightVision);
+                    DisableAndDestroyEffect(fpsCamInstance.ThermalVision);
+
+                    // Go to free camera mode
+                    ToggleCamera();
+                    ToggleUi();
                 }
             }
-
         }
 
         //DateTime? _lastOcclusionCullCheck = null;
@@ -312,6 +258,15 @@ namespace StayInTarkov.Coop.FreeCamera
 
             // One of the RegisteredPlayers will have the IsYourPlayer flag set, which will be our own Player instance
             return gameWorld.MainPlayer;
+        }
+
+        public void DisableAndDestroyEffect(MonoBehaviour effect)
+        {
+            if (effect != null)
+            {
+                effect.enabled = false;
+                Destroy(effect);
+            }
         }
 
         public void OnDestroy()

--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -339,6 +339,9 @@ namespace StayInTarkov
                 //// --------- Airdrop -----------------------
                 //new AirdropPatch().Enable();
 
+                //// --------- Settings -----------------------
+                SettingsLocationPatch.Enable();
+
                 //// --------- Screens ----------------
                 EnableSPPatches_Screens(Config);
 
@@ -350,9 +353,6 @@ namespace StayInTarkov
                 EnableSPPatches_Bots(Config);
 
                 new QTEPatch().Enable();
-
-               
-
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
- Added Aki Custom's SettingsLocationPatch, move the game client settings from ``C:\Users\(YourUsername)\AppData\Roaming\Battlestate Games\Escape from Tarkov\Settings`` to ``(Game directory)\user\sptSettings`` .
- - Original message from Aki: ``One concern people have playing SPT is of it altering their live files. Both SPT and live share the same config folder found in your appdata. With today's patch this is no longer the case, the majority of config settings are isolated to SPT and stored in SPT\user\sptSettings. Be aware this means the first time you start up 3.7.0 will be as if you've never played Tarkov before and default every setting.``


- When server has "showPlayerNameTags" set to true, player in the game can see their own nametag when they are in free camera mode. (In previous version, player can only see their own nametag when they are dead, so this simple fix make them see the nametag when they are alive)
- Fixes some no longer working features that checking "pmc" prefix in the ProfileId, due to Aki changed the logic in 3.8.0, these features are dead.
- Some free camera fixes when player are died.<details><summary>Changelog</summary>
Changed 'BlackScreenOnDeathTime' from 333 to 500
When dying, camera are no longer instant switch to the free camera, it is now similar to Live
Do not allow player switch the camera status if they are dead
Fixes dying while zoom-in will forever keep the zoom-in FOV in free camera mode
Fixes screen effect remove code are executed every single frame even it's already done his job
'TextureMask' added to the effect remove list
Make sure every effects is destroyed
</details>