### PR TITLE
Implement server types and P2P connection helper

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -102,9 +102,9 @@ namespace StayInTarkov.Configuration
             public bool SETTING_HeadshotsAlwaysKill { get; set; } = false;
             public bool SETTING_ShowFeed { get; set; } = true;
             public bool SETTING_ShowSITStatistics { get; set; } = true;
-            public HostProtocol SITHostProtocol { get; private set; }
-            public int SITWebSocketPort { get; set; } = 6970;
-            public int SITUDPPort { get; set; } = 6971;
+            //public HostProtocol SITHostProtocol { get; private set; }
+            //public int SITWebSocketPort { get; set; } = 6970;
+            //public int SITUDPPort { get; set; } = 6971;
 
             public bool AllPlayersSpawnTogether { get; set; } = true;
             public bool ArenaMode { get; set; } = false;
@@ -122,8 +122,8 @@ namespace StayInTarkov.Configuration
                 }
             }
 
-            public string SITUDPHostIPV4 { get; set; }
-            public string SITUDPHostIPV6 { get; set; }
+            //public string SITUDPHostIPV4 { get; set; }
+            //public string SITUDPHostIPV6 { get; set; }
 
             public void GetSettings()
             {
@@ -166,13 +166,13 @@ namespace StayInTarkov.Configuration
                 Logger.LogDebug($"ArenaMode: {ArenaMode}");
                 Logger.LogDebug($"ForceHighPingMode: {ForceHighPingMode}");
 
-                SITHostProtocol = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITHostProtocol", HostProtocol.TCP, new ConfigDescription("SIT Host Protocol.")).Value;
-                SITWebSocketPort = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITPort", 6970, new ConfigDescription("SIT TCP/Websocket Port DEFAULT = 6970")).Value;
-                SITUDPPort = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPPort", 6971, new ConfigDescription("SIT UDP Port DEFAULT = 6971")).Value;
-                SITUDPHostIPV4 = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPHostIPV4", "127.0.0.1", new ConfigDescription("The IPv4 to use when hosting a UDP Coop Session")).Value;
-                SITUDPHostIPV6 = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPHostIPV6", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", new ConfigDescription("The IPv6 to use when hosting a UDP Coop Session")).Value;
+                //SITHostProtocol = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITHostProtocol", HostProtocol.TCP, new ConfigDescription("SIT Host Protocol.")).Value;
+                //SITWebSocketPort = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITPort", 6970, new ConfigDescription("SIT TCP/Websocket Port DEFAULT = 6970")).Value;
+                //SITUDPPort = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPPort", 6971, new ConfigDescription("SIT UDP Port DEFAULT = 6971")).Value;
+                //SITUDPHostIPV4 = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPHostIPV4", "127.0.0.1", new ConfigDescription("The IPv4 to use when hosting a UDP Coop Session")).Value;
+                //SITUDPHostIPV6 = StayInTarkovPlugin.Instance.Config.Bind("Coop", "SITUDPHostIPV6", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", new ConfigDescription("The IPv6 to use when hosting a UDP Coop Session")).Value;
 
-                Logger.LogDebug($"SITWebSocketPort: {SITWebSocketPort}");
+                //Logger.LogDebug($"SITWebSocketPort: {SITWebSocketPort}");
 
                 if (ArenaMode)
                 {

--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -487,10 +487,11 @@ namespace StayInTarkov.Coop.Components
                 Logger.LogDebug(returnedJson);
                 JObject result = JObject.Parse(returnedJson);
                 MatchmakerAcceptPatches.SetGroupId(result["serverId"].ToString());
+                MatchmakerAcceptPatches.ServerType = result["serverType"].ToString();
+                MatchmakerAcceptPatches.ServerPort = int.Parse(result["serverPort"].ToString());
                 MatchmakerAcceptPatches.SetTimestamp(long.Parse(result["timestamp"].ToString()));
                 MatchmakerAcceptPatches.MatchingType = EMatchmakerType.GroupPlayer;
                 MatchmakerAcceptPatches.HostExpectedNumberOfPlayers = int.Parse(result["expectedNumberOfPlayers"].ToString());
-
 
                 FixesHideoutMusclePain();
                 DestroyThis();

--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -164,21 +164,13 @@ namespace StayInTarkov.Coop
             // ---------------------------------------------------------------------------------
             // Create GameClient(s)
             // TODO: Switch to GameClientTCP/GameClientUDP
-            if (
-               // PluginConfigSettings.Instance.CoopSettings.SITHostProtocol == PluginConfigSettings.CoopConfigSettings.HostProtocol.Both
-               //|| 
-               PluginConfigSettings.Instance.CoopSettings.SITHostProtocol == PluginConfigSettings.CoopConfigSettings.HostProtocol.TCP
-               )
+            if (MatchmakerAcceptPatches.ServerType == "relay")
             {
                 coopGame.GameClient = coopGame.GetOrAddComponent<GameClientTCP>();
             }
 
             // Udp Instanciate
-            if (
-                //PluginConfigSettings.Instance.CoopSettings.SITHostProtocol == PluginConfigSettings.CoopConfigSettings.HostProtocol.Both
-                //|| 
-                PluginConfigSettings.Instance.CoopSettings.SITHostProtocol == PluginConfigSettings.CoopConfigSettings.HostProtocol.UDP
-                )
+            if (MatchmakerAcceptPatches.ServerType == "p2p")
             {
                 if (MatchmakerAcceptPatches.IsClient)
                 {

--- a/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptPatches.cs
+++ b/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptPatches.cs
@@ -31,6 +31,8 @@ namespace StayInTarkov.Coop.Matchmaker
     {
         #region Fields/Properties
         public static EFT.UI.Matchmaker.MatchMakerAcceptScreen MatchMakerAcceptScreenInstance { get; set; }
+        public static string ServerType { get; set; }
+        public static int ServerPort { get; set; }
         public static Profile Profile { get; set; }
         public static EMatchmakerType MatchingType { get; set; } = EMatchmakerType.Single;
         public static bool IsServer => MatchingType == EMatchmakerType.GroupLeader;
@@ -240,15 +242,19 @@ namespace StayInTarkov.Coop.Matchmaker
             if (password != null)
                 objectToSend.Add("password", password);
 
-            string text = AkiBackendCommunication.Instance.PostJson("/coop/server/create", JsonConvert.SerializeObject(
+            string result = AkiBackendCommunication.Instance.PostJson("/coop/server/create", JsonConvert.SerializeObject(
                 objectToSend));
 
-            if (!string.IsNullOrEmpty(text))
+            if (!string.IsNullOrEmpty(result))
             {
+                JObject outJObject = JObject.Parse(result);
+
                 StayInTarkovHelperConstants.Logger.LogInfo($"CreateMatch:: Match Created for {profileId}");
                 SetGroupId(profileId);
+                ServerType = outJObject["serverType"].ToString();
+                ServerPort = int.Parse(outJObject["serverPort"].ToString());
                 SetTimestamp(timestamp);
-                MatchmakerAcceptPatches.MatchingType = EMatchmakerType.GroupLeader;
+                MatchingType = EMatchmakerType.GroupLeader;
                 return;
             }
 

--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -139,7 +139,7 @@ namespace StayInTarkov.Networking
 
             Logger.LogDebug("Request Instance is connecting to WebSocket");
 
-            var webSocketPort = PluginConfigSettings.Instance.CoopSettings.SITWebSocketPort;
+            var webSocketPort = MatchmakerAcceptPatches.ServerPort;
             var wsUrl = $"{StayInTarkovHelperConstants.GetREALWSURL()}:{webSocketPort}/{profile.ProfileId}?";
             Logger.LogDebug(webSocketPort);
             Logger.LogDebug(StayInTarkovHelperConstants.GetREALWSURL());
@@ -200,7 +200,7 @@ namespace StayInTarkov.Networking
 
         private void WebSocket_OnError()
         {
-            Logger.LogError($"Your PC has failed to connect and send data to the WebSocket with the port {PluginConfigSettings.Instance.CoopSettings.SITWebSocketPort} on the Server {StayInTarkovHelperConstants.GetBackendUrl()}! Application will now close.");
+            Logger.LogError($"Your PC has failed to connect and send data to the WebSocket with the port {MatchmakerAcceptPatches.ServerPort} on the Server {StayInTarkovHelperConstants.GetBackendUrl()}! Application will now close.");
             if (Singleton<ISITGame>.Instantiated)
             {
                 Singleton<ISITGame>.Instance.Stop(Singleton<GameWorld>.Instance.MainPlayer.ProfileId, Singleton<ISITGame>.Instance.MyExitStatus, Singleton<ISITGame>.Instance.MyExitLocation);

--- a/Source/Networking/GameServerUDP.cs
+++ b/Source/Networking/GameServerUDP.cs
@@ -7,6 +7,7 @@ using LiteNetLib.Utils;
 using StayInTarkov.Configuration;
 using StayInTarkov.Coop;
 using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.Matchmaker;
 using StayInTarkov.Coop.NetworkPacket;
 using StayInTarkov.Coop.Players;
 
@@ -30,6 +31,7 @@ namespace StayInTarkov.Networking
     public class GameServerUDP : MonoBehaviour, INetEventListener, INetLogger
     {
         private LiteNetLib.NetManager _netServer;
+        public P2PConnectionHelper _p2pConnectionHelper;
         public NetPacketProcessor _packetProcessor = new();
         private NetDataWriter _dataWriter = new();
         public CoopPlayer MyPlayer => Singleton<GameWorld>.Instance.MainPlayer as CoopPlayer;
@@ -77,16 +79,25 @@ namespace StayInTarkov.Networking
                 AutoRecycle = true,
                 IPv6Enabled = false,
                 EnableStatistics = true,
-                NatPunchEnabled = true
+                NatPunchEnabled = false
             };
 
+            _p2pConnectionHelper = new P2PConnectionHelper(_netServer);
+            _p2pConnectionHelper.Connect();
+
+            /*
             _netServer.Start(
                 PluginConfigSettings.Instance.CoopSettings.SITUDPHostIPV4
                 , PluginConfigSettings.Instance.CoopSettings.SITUDPHostIPV6
                 , PluginConfigSettings.Instance.CoopSettings.SITUDPPort);
+            */
 
-            Logger.LogDebug($"Server started on port {_netServer.LocalPort}.");
-            EFT.UI.ConsoleScreen.Log($"Server started on port {_netServer.LocalPort}.");
+
+
+            //_netServer.Start(MatchmakerAcceptPatches.ServerPort);
+
+            //Logger.LogDebug($"Server started on port {_netServer.LocalPort}.");
+            //EFT.UI.ConsoleScreen.Log($"Server started on port {_netServer.LocalPort}.");
             //NotificationManagerClass.DisplayMessageNotification($"Server started on port {_netServer.LocalPort}.",
             //    EFT.Communications.ENotificationDurationType.Default, EFT.Communications.ENotificationIconType.EntryPoint);
         }

--- a/Source/Networking/P2PConnectionHelper.cs
+++ b/Source/Networking/P2PConnectionHelper.cs
@@ -1,0 +1,180 @@
+﻿using BepInEx.Logging;
+using LiteNetLib.Utils;
+using StayInTarkov.Coop.Matchmaker;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using WebSocketSharp;
+
+namespace StayInTarkov.Networking
+{
+    public class NatTraversalRequest
+    {
+        private P2PConnectionHelper P2PConnectionHelper { get; set; }
+        private TaskCompletionSource<IPEndPoint> NatTraversalCompletionSource;
+        private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("NAT Traversal Request");
+
+        public NatTraversalRequest(P2PConnectionHelper p2PConnectionHelper) 
+        { 
+            P2PConnectionHelper = p2PConnectionHelper;
+
+            P2PConnectionHelper.WebSocket.OnMessage += WebSocket_OnMessage;
+            P2PConnectionHelper.WebSocket.OnError += WebSocket_OnError;
+        }
+
+        private void WebSocket_OnMessage(object sender, WebSocketSharp.MessageEventArgs e)
+        {
+            if (e == null)
+                return;
+
+            if (string.IsNullOrEmpty(e.Data))
+                return;
+
+            ProcessMessage(e.Data);
+        }
+
+        private void WebSocket_OnError(object sender, WebSocketSharp.ErrorEventArgs e)
+        {
+            Logger.LogInfo("WebSocket Error:" + e.Message);
+            P2PConnectionHelper.WebSocket.Close();
+        }
+
+        private void ProcessMessage(string message)
+        {
+            Logger.LogInfo("received message: " + message);
+
+            var messageSplit = message.Split(':');
+
+            if (messageSplit[0] == "punch_response")
+            {
+                var serverIp = messageSplit[1];
+                var serverPort = messageSplit[2];
+
+                var endPoint = new IPEndPoint(IPAddress.Parse(serverIp), int.Parse(serverPort));
+
+                P2PConnectionHelper.NetManager.Start(MatchmakerAcceptPatches.ServerPort);
+                P2PConnectionHelper.PunchNat(endPoint);
+
+                NatTraversalCompletionSource.SetResult(endPoint);
+            }
+        }
+
+        public async Task<IPEndPoint> NatPunchRequestAsync(string serverId, string profileId)
+        {
+            NatTraversalCompletionSource = new TaskCompletionSource<IPEndPoint>();
+
+            // perform STUN query to open a public endpoint and punch it later.
+            var stunEndPoint = STUNHelper.OpenPublicEndpoint(MatchmakerAcceptPatches.ServerPort);
+
+            if (stunEndPoint != null)
+            {
+                // punch_request:serverId:profileId:publicIp:publicPort
+                string punchRequestPacket = $"punch_request:{serverId}:{profileId}:{stunEndPoint.Address}:{stunEndPoint.Port}";
+
+                P2PConnectionHelper.WebSocket.Send(punchRequestPacket);
+
+                var endPoint = await NatTraversalCompletionSource.Task;
+
+                return endPoint;
+            }
+
+            return null;
+        }
+
+        public async Task<IPEndPoint> UpnpRequest(string serverId, string profileId)
+        {
+            var endPoint = await NatTraversalCompletionSource.Task;
+
+            return endPoint;
+        }
+    }
+
+    public class P2PConnectionHelper
+    {
+        public LiteNetLib.NetManager NetManager;
+        public WebSocket WebSocket { get; set; }
+
+        public IPEndPoint PublicEndPoint { get; set; }
+
+        private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("P2P Connection Helper");
+
+        public P2PConnectionHelper(LiteNetLib.NetManager netManager)
+        {
+            NetManager = netManager;
+        }
+
+        public void Connect()
+        {
+            var wsUrl = $"{StayInTarkovHelperConstants.GetREALWSURL()}:6971/{MatchmakerAcceptPatches.Profile.ProfileId}?";
+
+            WebSocket = new WebSocket(wsUrl);
+            WebSocket.WaitTime = TimeSpan.FromMinutes(1);
+            WebSocket.EmitOnPing = true;
+            WebSocket.Connect();
+
+            WebSocket.OnError += WebSocket_OnError;
+            WebSocket.OnMessage += WebSocket_OnMessage;
+        }
+
+        private void WebSocket_OnMessage(object sender, WebSocketSharp.MessageEventArgs e)
+        {
+            if (e == null)
+                return;
+
+            if (string.IsNullOrEmpty(e.Data))
+                return;
+
+            ProcessMessage(e.Data);
+        }
+
+        private void WebSocket_OnError(object sender, WebSocketSharp.ErrorEventArgs e)
+        {
+            Logger.LogInfo("WebSocket Error:" + e.Message);
+            WebSocket.Close();
+        }
+
+        private void ProcessMessage(string message)
+        {
+            Logger.LogInfo("received message: " + message);
+
+            var messageSplit = message.Split(':');
+
+            if (messageSplit[0] == "punch_request")
+            {
+                var profileId = messageSplit[1];
+                var ipToPunch = messageSplit[2];
+                var portToPunch = messageSplit[3];
+
+                if(PublicEndPoint == null)
+                {
+                    PublicEndPoint = STUNHelper.OpenPublicEndpoint(MatchmakerAcceptPatches.ServerPort);
+                }
+
+                string punchResponsePacket = $"punch_response:{profileId}:{PublicEndPoint.Address}:{PublicEndPoint.Port}";
+                WebSocket.Send(punchResponsePacket);
+
+                NetManager.Start(MatchmakerAcceptPatches.ServerPort);
+
+                PunchNat(new IPEndPoint(IPAddress.Parse(ipToPunch), int.Parse(portToPunch)));
+            }
+        }
+
+        public void PunchNat(IPEndPoint endPoint)
+        {
+            // bogus punch data
+            NetDataWriter resp = new NetDataWriter();
+            resp.Put(9999);
+
+            Logger.LogInfo($"Punching: {endPoint.Address.ToString()}:{endPoint.Port}");
+
+            // send a couple of packets to punch a hole
+            for (int i = 0; i < 10; i++)
+            {
+                NetManager.SendUnconnectedMessage(resp, endPoint);
+            }
+        }
+    }
+}

--- a/Source/Networking/STUNHelper.cs
+++ b/Source/Networking/STUNHelper.cs
@@ -1,0 +1,57 @@
+﻿using StayInTarkov.Configuration;
+using STUN.Attributes;
+using STUN;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+
+namespace StayInTarkov.Networking
+{
+    public static class STUNHelper
+    {
+        private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("STUN Helper");
+
+        public static bool Query(int localPort, out STUNQueryResult queryResult)
+        {
+            queryResult = new STUNQueryResult();
+
+            var stunUdpClient = new UdpClient();
+            stunUdpClient.Client.Bind(new IPEndPoint(IPAddress.Any, localPort));
+
+            // Google's STUN server should be pretty safe to use in the long term.
+            if (!STUNUtils.TryParseHostAndPort("stun.l.google.com:19302", out IPEndPoint stunEndPoint))
+                throw new Exception("Failed to resolve STUN server address!");
+
+            try
+            {
+                queryResult = STUNClient.Query(stunUdpClient.Client, stunEndPoint, STUNQueryType.ExactNAT, NATTypeDetectionRFC.Rfc3489);
+                //var queryResult = STUNClient.Query(stunEndPoint, STUNQueryType.ExactNAT, true, NATTypeDetectionRFC.Rfc3489);
+            }
+            catch (STUNQueryErrorException ex)
+            {
+                Logger.LogError(ex.Error);
+                return false;
+            }
+
+            stunUdpClient.Client.Close();
+
+            return true;
+        }
+
+        public static IPEndPoint OpenPublicEndpoint(int port)
+        {
+            // we dont need to use SITUDPPort as the local port, but this works for now.
+            if (Query(port, out STUNQueryResult stunQueryResult))
+            {
+                return stunQueryResult.PublicEndPoint;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/StayInTarkov.csproj
+++ b/Source/StayInTarkov.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="STUN" Version="0.5.1--date20201107-0659.git-ca37d4e" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.39" IncludeAssets="compile" />
   </ItemGroup>
   


### PR DESCRIPTION
- Implemented server types to allow a match host to use relay (websocket on 6970) or P2P (UDP on 6972) networking. This configuration is defined in coopConfig.json and transmitted to the coop match instance.

- Implemented a P2P Connection Helper to allow for NAT punching and UPNP mapping. This only applies to P2P networking. The P2P Helper is communicating with the backend server using websocket on port 6971, configurable in coopConfig.json.

- NAT punching uses a public endpoint created by a STUN query. This is necessary because the backend server might be on the same network as the match host and therefore we can't get a public endpoint locally.

- Removed all configs related to IPs and ports in com.sit.core.cfg. The ports are now configured in coopConfig.json and the server will listen on all adapters.

From now on, three ports will need to be forwarded on the backend server host: 6969, 6970 and 6971. 6972 needs to be forwarded on the match host instead because of P2P networking. If forwarding is not possible, NAT punching will be attempted to establish connection.

TODO:
- Add upnp mapping
- Implement upnp requests in P2P Helper
- Logic to attempt nat traversal, upnp or direct port forwarding connection before giving up.
- Add security to the p2p helper