### PR TITLE
Disable "ResetDiscardLimits()" call

### DIFF
--- a/Source/Coop/Controllers/CoopInventory/CoopInventoryController.cs
+++ b/Source/Coop/Controllers/CoopInventory/CoopInventoryController.cs
@@ -148,8 +148,8 @@ namespace StayInTarkov.Coop.Controllers.CoopInventory
         {
             BepInLogger = BepInEx.Logging.Logger.CreateLogSource(nameof(CoopInventoryController));
             Player = player;
-            if (player.Side != EPlayerSide.Savage && !IsDiscardLimitsFine(DiscardLimits))
-                ResetDiscardLimits();
+            /*if (player.Side != EPlayerSide.Savage && !IsDiscardLimitsFine(DiscardLimits))
+                ResetDiscardLimits();*/
         }
 
         public override Task<IResult> LoadMagazine(BulletClass sourceAmmo, MagazineClass magazine, int loadCount, bool ignoreRestrictions)


### PR DESCRIPTION
Should no longer causing infinite error loop about "EFT.Player.LateUpdate()".