### PR TITLE
Add Configurable Match Start Timeout

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -118,6 +118,8 @@ namespace StayInTarkov.Configuration
             public bool ForceHighPingMode { get; set; } = false;
             public bool RunThroughOnServerStop { get; set; } = true;
 
+            public int WaitingTimeBeforeStart { get; private set; }
+
             public int BlackScreenOnDeathTime
             {
                 get
@@ -154,6 +156,9 @@ namespace StayInTarkov.Configuration
 
                 ForceHighPingMode = StayInTarkovPlugin.Instance.Config.Bind("Coop", "ForceHighPingMode", false
                         , new ConfigDescription("Forces the High Ping Mode which allows some actions to not round-trip. This may be useful if you have large input lag")).Value;
+
+                WaitingTimeBeforeStart = Config.Bind("Coop", "WaitingTimeBeforeStart", 120
+                        , new ConfigDescription("Time in seconds to wait for players before starting the game automatically")).Value;
 
                 SETTING_ShowSITStatistics = StayInTarkovPlugin.Instance.Config.Bind
                  ("Coop", "ShowSITStatistics", true, new ConfigDescription("Enable the SIT statistics on the top left of the screen which shows ping, player count, etc.")).Value;

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -662,45 +662,50 @@ namespace StayInTarkov.Coop.SITGameModes
 
             // ---------------------------------------------
             // Here we can wait for other players, if desired
+            TimeSpan waitTimeout = TimeSpan.FromSeconds(PluginConfigSettings.Instance.CoopSettings.WaitingTimeBeforeStart);
+
             await Task.Run(async () =>
             {
                 if (coopGameComponent != null)
                 {
+                    System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
                     while (coopGameComponent.PlayerUsers == null)
                     {
                         Logger.LogDebug($"{nameof(vmethod_2)}: {nameof(coopGameComponent.PlayerUsers)} is null");
                         await Task.Delay(1000);
                     }
 
-                    var numbersOfPlayersToWaitFor = SITMatchmaking.HostExpectedNumberOfPlayers - coopGameComponent.PlayerUsers.Count();
                     do
                     {
-                        if (coopGameComponent.PlayerUsers == null)
+                        if (coopGameComponent.PlayerUsers == null || coopGameComponent.PlayerUsers.Count() == 0)
                         {
-                            Logger.LogDebug($"{nameof(vmethod_2)}: {nameof(coopGameComponent.PlayerUsers)} is null");
-                            await Task.Delay(1000);
-                            continue;
-                        }
-
-                        if (coopGameComponent.PlayerUsers.Count() == 0)
-                        {
-                            Logger.LogDebug($"{nameof(vmethod_2)}: {nameof(coopGameComponent.PlayerUsers)} is empty");
+                            Logger.LogDebug($"{nameof(vmethod_2)}: PlayerUsers is null or empty");
                             await Task.Delay(1000);
                             continue;
                         }
 
                         var progress = coopGameComponent.PlayerUsers.Count() / SITMatchmaking.HostExpectedNumberOfPlayers;
-                        numbersOfPlayersToWaitFor = SITMatchmaking.HostExpectedNumberOfPlayers - coopGameComponent.PlayerUsers.Count();
+                        var numbersOfPlayersToWaitFor = SITMatchmaking.HostExpectedNumberOfPlayers - coopGameComponent.PlayerUsers.Count();
                         if (SITMatchmaking.TimeHasComeScreenController != null)
                         {
                             SITMatchmaking.TimeHasComeScreenController.ChangeStatus($"Waiting for {numbersOfPlayersToWaitFor} Player(s)", progress);
                         }
 
+                        if (stopwatch.Elapsed >= waitTimeout)
+                        {
+                            Logger.LogInfo("Timeout reached. Proceeding with current players.");
+                            break; // Exit the loop due to timeout
+                        }
+
                         await Task.Delay(1000);
 
-                    } while (numbersOfPlayersToWaitFor > 0);
+                    } while (true);
+
+                    stopwatch.Stop();
                 }
             });
+
 
             // ---------------------------------------------
 


### PR DESCRIPTION
Added a setting to tweak how long we wait for players before starting a game. Now, you can set your own wait time, making it easier to start playing when you're ready, without being stuck in Waiting for Players.