### PR TITLE
Fix health controller in raid

### DIFF
--- a/Source/Health/AssignHealthControllerToPlayerInRaid.cs
+++ b/Source/Health/AssignHealthControllerToPlayerInRaid.cs
@@ -17,7 +17,7 @@ namespace StayInTarkov.Health
 
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(Player), nameof(Player.Init));
+            return AccessTools.Method(typeof(LocalPlayer), nameof(LocalPlayer.Init));
         }
 
         [PatchPostfix]

--- a/Source/Health/AssignHealthControllerToPlayerInRaid.cs
+++ b/Source/Health/AssignHealthControllerToPlayerInRaid.cs
@@ -1,4 +1,6 @@
 ﻿using EFT;
+using HarmonyLib;
+using StayInTarkov.Networking;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -15,7 +17,7 @@ namespace StayInTarkov.Health
 
         protected override MethodBase GetTargetMethod()
         {
-            return ReflectionHelpers.GetMethodForType(typeof(LocalPlayer), "Init");
+            return AccessTools.Method(typeof(Player), nameof(Player.Init));
         }
 
         [PatchPostfix]
@@ -33,15 +35,16 @@ namespace StayInTarkov.Health
             await __result;
 
             var listener = HealthListener.Instance;
-            if (profile?.Id.StartsWith("pmc") == true && __instance.IsYourPlayer)
+
+            if (profile?.Id.Equals(AkiBackendCommunication.Instance.ProfileId, StringComparison.InvariantCultureIgnoreCase) ?? false && __instance.IsYourPlayer)
             {
-                //Logger.LogInfo($"Hooking up health listener to profile: {profile.Id}");
+                Logger.LogDebug($"Hooking up health listener to profile: {profile.Id}");
                 listener.Init(__instance.HealthController, true);
-                //Logger.LogInfo($"HealthController instance: {__instance.HealthController.GetHashCode()}");
+                Logger.LogDebug($"HealthController instance: {__instance.HealthController.GetHashCode()}");
             }
             else
             {
-                //Logger.LogInfo($"Skipped on HealthController instance: {__instance.HealthController.GetHashCode()} for profile id: {profile?.Id}");
+                Logger.LogDebug($"Skipped on HealthController instance: {__instance.HealthController.GetHashCode()} for profile id: {profile?.Id}");
             }
 
         }


### PR DESCRIPTION
profile?.Id.StartsWith("pmc") is now not exist, so using code like the one in SPT-Aki to fix HealthControllerInRaid.
Also makes healing after raid working again.

Results:
![R1](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/a71aefba-e602-4d5f-9579-2ec62c316e83)
![R2](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/39ae48e6-de20-4d02-9e5b-9fecce61ad64)
![R3](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/4d4a40a7-4e25-4551-98ec-62c60bd95b48)
![R4](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/05709ea2-5b68-4db0-b7b2-fb902db57730)
