### PR TITLE
Fix for Scav Mode shooting PMC's

### DIFF
--- a/Source/AkiSupport/Singleplayer/AkiSingleplayerPlugin.cs
+++ b/Source/AkiSupport/Singleplayer/AkiSingleplayerPlugin.cs
@@ -48,6 +48,7 @@ namespace StayInTarkov.AkiSupport.Singleplayer
                 new ScavSellAllPriceStorePatch().Enable();
                 new ScavEncyclopediaPatch().Enable();
                 new ScavItemCheckmarkPatch().Enable();
+                new IsHostileToEverybodyPatch().Enable();
                 
                 // Unused Patches
                 //new OfflineSaveProfilePatch().Enable();

--- a/Source/AkiSupport/Singleplayer/Patches/ScavMode/IsHostileToEverybodyPatch.cs
+++ b/Source/AkiSupport/Singleplayer/Patches/ScavMode/IsHostileToEverybodyPatch.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using EFT;
+
+namespace StayInTarkov.AkiSupport.Singleplayer.Patches.ScavMode
+{
+    public class IsHostileToEverybodyPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            var desiredType = typeof(ServerBotSettingsClass);
+            var desiredMethod = desiredType.GetMethod("IsHostileToEverybody", BindingFlags.Public | BindingFlags.Static);
+
+            return desiredMethod;
+        }
+
+        [PatchPrefix]
+        private static bool PatchPrefix(WildSpawnType role, ref bool __result)
+        {
+            if (role == WildSpawnType.sptUsec || role == WildSpawnType.sptBear)
+            {
+                __result = true;
+                return false;
+            }
+            return true;
+        }
+    }
+}
+


### PR DESCRIPTION
The IsHostileToEverybody method was looking for the spawn types sptUsec and sptBear in EFT's ServerBotSettingsClass.dictionary_0, which does not contain them.