### PR TITLE
Fixes detecting illegal copy of the game

### DIFF
--- a/Source/EssentialPatches/LegalGameCheck.cs
+++ b/Source/EssentialPatches/LegalGameCheck.cs
@@ -30,6 +30,7 @@ namespace StayInTarkov.EssentialPatches
             catch (Exception ex)
             {
                 StayInTarkovHelperConstants.Logger.LogError(ex.ToString());
+                ProcessLGF(Convert.ToBoolean(byte.MaxValue & -32 / byte.MaxValue - -1 - 1));
             }
 
             Checked = true;


### PR DESCRIPTION
Because of C# automatically fill up ``LegalGameFound`` with 4 bytes of 0, if an exception happens when running check, user will bypass the legal check and go into the game.