### PR TITLE
Enable examine item feature in-rarid

### DIFF
--- a/Source/Coop/Players/CoopPlayer.cs
+++ b/Source/Coop/Players/CoopPlayer.cs
@@ -92,8 +92,8 @@ namespace StayInTarkov.Coop.Players
             player.BepInLogger = BepInEx.Logging.Logger.CreateLogSource("CoopPlayer");
 
             InventoryControllerClass inventoryController = isYourPlayer && !isClientDrone
-                ? new CoopInventoryController(player, profile, true)
-                : new CoopInventoryControllerClient(player, profile, true);
+                ? new CoopInventoryController(player, profile, false)
+                : new CoopInventoryControllerClient(player, profile, false);
 
             foreach(var item in profile.Inventory.AllRealPlayerItems)
             {


### PR DESCRIPTION
Re-enable the feature that exists in the Live:
Some items are unexamined and you will have to examine it first to see the item info.
![item](https://github.com/stayintarkov/StayInTarkov.Client/assets/45044404/d381ad1c-0318-4934-ac32-7ce0c94379c5)
