### PR TITLE
Fixed dogtag error and getting the real killing weapon

### DIFF
--- a/Source/AkiSupport/Singleplayer/Patches/Quests/DogtagPatch.cs
+++ b/Source/AkiSupport/Singleplayer/Patches/Quests/DogtagPatch.cs
@@ -103,7 +103,17 @@ namespace StayInTarkov.AkiSupport.Singleplayer.Patches.Quests
             itemComponent.Status = "Killed by";
             itemComponent.KillerAccountId = aggressor.Profile.AccountId;
             itemComponent.KillerProfileId = aggressor.Profile.Id;
-            itemComponent.WeaponName = damageInfo.Weapon.Name;
+
+            if (damageInfo.Weapon == null) // Fixed an issue where PMCs sometimes failed to generate dog tags after being killed by knives or grenades, keep standing and could not be looted.
+            {
+                Logger.LogDebug($"DogtagPatch Killed by weapon: unknown");
+                itemComponent.WeaponName = "Unknown";
+            }
+            else 
+            {
+                Logger.LogDebug($"DogtagPatch Killed by weapon: {damageInfo.Weapon.Name}");
+                itemComponent.WeaponName = damageInfo.Weapon.Name;
+            }
 
             if (__instance.Profile.Info.Experience > 0)
             {

--- a/Source/Coop/Players/CoopPlayer.cs
+++ b/Source/Coop/Players/CoopPlayer.cs
@@ -203,7 +203,10 @@ namespace StayInTarkov.Coop.Players
             {
                 damagePacket.AggressorProfileId = damageInfo.Player.iPlayer.ProfileId;
                 if (damageInfo.Weapon != null)
+                {
                     damagePacket.AggressorWeaponId = damageInfo.Weapon.Id;
+                    damagePacket.AggressorWeaponTpl = damageInfo.Weapon.TemplateId;
+                }
             }
             GameClient.SendData(damagePacket.Serialize());
 


### PR DESCRIPTION
1.Fixed an issue where PMCs (real players and bots) sometimes failed to generate dogtags after being killed by knives or grenades, keep standing and could not be looted.
2.Get the real killing weapon and generate to dogtags.