### PR TITLE
Fix player group extract

### DIFF
--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -661,6 +661,9 @@ namespace StayInTarkov.Coop.SITGameModes
             coopGameComponent.Players.TryAdd(profile.Id, (CoopPlayer)myPlayer);
             coopGameComponent.ProfileIdsUser.Add(profile.Id);
 
+            // Set Group Id for host
+            myPlayer.Profile.Info.GroupId = "SIT";
+
             SendPlayerDataToServer(myPlayer);
 
             //SendOrReceiveSpawnPoint(myPlayer);


### PR DESCRIPTION
Set GroupId for host player to make all players signed to the same group

Tested In Ground Zero Mira extract
![Exit](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/aa020e35-928f-48f7-b3a3-f71da2c7a8e0)
