### PR TITLE
Further fix QuickKnife

### DIFF
--- a/Source/Coop/Players/CoopPlayerClient.cs
+++ b/Source/Coop/Players/CoopPlayerClient.cs
@@ -549,7 +549,7 @@ namespace StayInTarkov.Coop.Players
         public override void Proceed(KnifeComponent knife, Callback<IQuickKnifeKickController> callback, bool scheduled = true)
         {
             Func<QuickKnifeKickController> controllerFactory = () => QuickKnifeKickController.smethod_8<QuickKnifeKickController>(this, knife);
-            Process<QuickKnifeKickController, IQuickKnifeKickController> process = new Process<QuickKnifeKickController, IQuickKnifeKickController>(this, controllerFactory, knife.Item, fastHide: true, AbstractProcess.Completion.Sync, AbstractProcess.Confirmation.Unknown, skippable: false);
+            Process<QuickKnifeKickController, IQuickKnifeKickController> process = new Process<QuickKnifeKickController, IQuickKnifeKickController>(this, controllerFactory, knife.Item, fastHide: true, AbstractProcess.Completion.Sync, AbstractProcess.Confirmation.Succeed, skippable: false);
             Action confirmCallback = delegate
             {
                 


### PR DESCRIPTION
Still needs further fixes, currently it ensures anim spawn and drop correctly (no packet lost), but you will often see the main weapon shows instead of the knife.