### PR TITLE
fix "not allowed to be called from MonoBehaviour constructor" error

### DIFF
--- a/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
@@ -127,7 +127,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
         Camera GameCamera { get; set; }
 
-        public ActionPacketHandlerComponent ActionPacketHandler { get; } = CoopPatches.CoopGameComponentParent.GetOrAddComponent<ActionPacketHandlerComponent>();
+        public ActionPacketHandlerComponent ActionPacketHandler { get; set; }
 
         #endregion
 
@@ -180,6 +180,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             Logger = BepInEx.Logging.Logger.CreateLogSource(nameof(SITGameComponent));
             Logger.LogDebug($"{nameof(SITGameComponent)}:{nameof(Awake)}");
 
+            ActionPacketHandler = CoopPatches.CoopGameComponentParent.GetOrAddComponent<ActionPacketHandlerComponent>();
             gameObject.AddComponent<SITGameGUIComponent>();
 
             SITCheck();


### PR DESCRIPTION
Fixes the error below that prevented to run the game in debug mode.

```
[Error  :SITGameServerClientDataProcessing] UnityEngine.UnityException: GetComponentFastPath can only be called from the main thread.
Constructors and field initializers will be executed from the loading thread when loading a scene.
Don't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.
  at (wrapper managed-to-native) UnityEngine.GameObject.GetComponentFastPath(UnityEngine.GameObject,System.Type,intptr)
  at UnityEngine.GameObject.GetComponent[T] () [0x00021] in <ca21460feb9c47d0ac337b9893474cc6>:0 
  at StayInTarkov.Coop.Components.CoopGameComponents.CoopGameComponent.GetCoopGameComponent () [0x00014] in C:\StayInTarkov.Client\Source\Coop\Components\CoopGameComponents\CoopGameComponent.cs:138 
  at StayInTarkov.Networking.SITGameServerClientDataProcessing.ProcessPacketBytes (System.Byte[] data, System.String sData) [0x000de] in C:\StayInTarkov.Client\Source\Networking\SITGameServerClientDataProcessing.cs:84 
```