### PR TITLE
[github workflow] tentative fix for comment-on-pr

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -51,6 +51,7 @@ jobs:
           echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
       - name: Find Comment
         id: find-comment
+        continue-on-error: true
         uses: peter-evans/find-comment@v2
         with:
           issue-number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
Looks like we need to allow failure for the find-comment step
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
https://github.com/stayintarkov/StayInTarkov.Client/actions/workflows/comment-on-pr.yml