### PR TITLE
[github workflow] fix comment-on-pr

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -14,12 +14,27 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Get Artifact and Pull request info
+      - name: Find associated pull request
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
+            }
+            const pullRequestNumber = items[0].number
+            console.info("Pull request number is", pullRequestNumber)
+            return pullRequestNumber
+      - name: Get Artifact ID
         env:
           GITHUB_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
         run: |
           PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
           echo "Previous Job ID: $PREVIOUS_JOB_ID"
@@ -29,7 +44,7 @@ jobs:
           echo "Previous Suite ID: $SUITE_ID"
           echo "SUITE_ID=$SUITE_ID" >> "$GITHUB_ENV"
           
-          ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+          ARTIFACT_ID=$(gh api "/repos/${{ github.repository }}/actions/artifacts" \
             --jq ".artifacts.[] |
             select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
             select(.expired==false) |
@@ -37,34 +52,21 @@ jobs:
           
           echo "Artifact ID: $ARTIFACT_ID"
           echo "ARTIFACT_ID=$ARTIFACT_ID" >> "$GITHUB_ENV"
-          
-          PR_NUMBER=$(jq -r '.pull_requests[0].number' \
-            <<< "$WORKFLOW_RUN_EVENT_OBJ")
-          
-          echo "Pull request Number: $PR_NUMBER"
-          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
-          
-          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' \
-            <<< "$WORKFLOW_RUN_EVENT_OBJ")
-          
-          echo "Head SHA: $HEAD_SHA"
-          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
       - name: Find Comment
         id: find-comment
         continue-on-error: true
         uses: peter-evans/find-comment@v2
         with:
-          issue-number: ${{ env.PR_NUMBER }}
+          issue-number: ${{ steps.pr.outputs.result }}
           comment-author: 'github-actions[bot]'
       - name: Create or Update Comment
         if: steps.find-comment.outputs.comment-id == ''  # Comment not found
         env:
           JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}"
           ARTIFACT_URL: "https://github.com/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.ARTIFACT_ID }}"
-          HEAD_SHA: "${{ env.HEAD_SHA }}"
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ env.PR_NUMBER }}
+          issue-number: ${{ steps.pr.outputs.result }}
           body: |-
             ![badge]
             
@@ -72,7 +74,7 @@ jobs:
             
             | Name     | Link                    |
             | -------- | ----------------------- |
-            | Commit   | ${{ env.HEAD_SHA }}     |
+            | Commit   | ${{ github.event.workflow_run.head_sha }}     |
             | Logs     | ${{ env.JOB_PATH }}     |
             | Download | ${{ env.ARTIFACT_URL }} |
             


### PR DESCRIPTION
Implements a workaround to the 3+ year old issue that PR numbers are not always available in the workflow_run event object.
See https://github.com/orgs/community/discussions/25220