### PR TITLE
Fix add back boss spawn fixes

### DIFF
--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -501,9 +501,9 @@ namespace StayInTarkov.Coop.SITGameModes
                     continue;
                 }
                 float bossChance = bossLocationSpawn.BossChance;
-#if DEBUG
-                bossChance = 100f;
-#endif
+//#if DEBUG
+//                bossChance = 100f;
+//#endif
                 if (CanSpawnCultist(GameWorldTime.Hour) && (bossLocationSpawn.BossType == WildSpawnType.sectantPriest || bossLocationSpawn.BossType == WildSpawnType.sectantWarrior))
                 {
                     Logger.LogDebug($"Block spawn of Sectant (Cultist) in day time in hour {GameWorldTime.Hour}!");


### PR DESCRIPTION
For some reason Git decided to roll back some changes I made to boss spawning when another bunch of PRs came in. This adds the code back in to:

- Fix boss spawn rate (so its not 100% all of the time)
- Add followers to bosses when needed