### PR TITLE
Fix the issue where the isAI flag is was not set correctly

### DIFF
--- a/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
@@ -944,7 +944,8 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                         continue;
 
                     Vector3 newPosition = PlayersToSpawnPacket[p.Key].BodyPosition;
-                    ProcessPlayerBotSpawn(PlayersToSpawnPacket[p.Key], p.Key, newPosition, false, PlayersToSpawnPacket[p.Key].InitialInventoryMongoId);
+                    //ProcessPlayerBotSpawn(PlayersToSpawnPacket[p.Key], p.Key, newPosition, false, PlayersToSpawnPacket[p.Key].InitialInventoryMongoId);
+                    ProcessPlayerBotSpawn(PlayersToSpawnPacket[p.Key], p.Key, newPosition, PlayersToSpawnPacket[p.Key].IsAI, PlayersToSpawnPacket[p.Key].InitialInventoryMongoId);
                 }
 
 

--- a/Source/Coop/Components/CoopGameComponents/SITGameGUIComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameGUIComponent.cs
@@ -135,7 +135,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
             //OnGUI_DrawPlayerList(rect);
             OnGUI_DrawPlayerFriendlyTags(rect);
-            //OnGUI_DrawPlayerEnemyTags(rect);
+            OnGUI_DrawPlayerEnemyTags(rect);
 
         }
 

--- a/Source/Coop/NetworkPacket/Player/PlayerInformationPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/PlayerInformationPacket.cs
@@ -23,6 +23,7 @@ namespace StayInTarkov.Coop.NetworkPacket.Player
 {
     /// <summary>
     /// Paulov: I have based this on GMessage2, which is used during ObservedPlayerView creation
+    /// This is the Packet that holds the data that is used to spawn characters/players on clients.
     /// </summary>
     public sealed class PlayerInformationPacket : BasePlayerPacket
     {

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -631,7 +631,7 @@ namespace StayInTarkov.Coop.SITGameModes
                 coopGameComponent.Players.TryAdd(profile.Id, (CoopPlayer)botPlayer);
                 coopGameComponent.ProfileIdsAI.Add(profile.Id);
 
-                SendPlayerDataToServer(botPlayer, position);
+                SendPlayerDataToServer(botPlayer, position, true);
 
             }
             return botPlayer;
@@ -806,7 +806,7 @@ namespace StayInTarkov.Coop.SITGameModes
             // Set Group Id for host
             myPlayer.Profile.Info.GroupId = "SIT";
             myPlayer.Transform.position = spawnPoint.Position;
-            SendPlayerDataToServer(myPlayer, spawnPoint.Position);
+            SendPlayerDataToServer(myPlayer, spawnPoint.Position, false);
 
             //SendOrReceiveSpawnPoint(myPlayer);
 
@@ -1018,7 +1018,7 @@ namespace StayInTarkov.Coop.SITGameModes
             GameClient.SendData(requestSpawnPlayersPacket.Serialize());
         }
 
-        public static void SendPlayerDataToServer(LocalPlayer player, Vector3 position)
+        public static void SendPlayerDataToServer(LocalPlayer player, Vector3 position, bool isAI)
         {
 #if DEBUG
             Logger.LogDebug($"{nameof(SendPlayerDataToServer)}");
@@ -1027,6 +1027,7 @@ namespace StayInTarkov.Coop.SITGameModes
             // Sends out to all clients that this Character has spawned
             var infoPacket = SpawnPlayersPacket.CreateInformationPacketFromPlayer(player);
             infoPacket.BodyPosition = position;
+            infoPacket.IsAI = isAI;
             var spawnPlayersPacket = new SpawnPlayersPacket([infoPacket]);
             Networking.GameClient.SendData(spawnPlayersPacket.Serialize());
         }


### PR DESCRIPTION
- Fix the issue where the isAI flag is was not set correctly before sending to clients
- Fix the issue where clients were detecting AI as players and therefore the player tags were appearing