### PR TITLE
[feature] live-like car extracts

### DIFF
--- a/Source/Coop/NetworkPacket/World/UpdateExfiltrationPointPacket.cs
+++ b/Source/Coop/NetworkPacket/World/UpdateExfiltrationPointPacket.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace StayInTarkov.Coop.NetworkPacket.World
+{
+    /// <summary>
+    /// Sent when an exfil point changes status. Contains information needed to synchronize countdown exfils
+    /// </summary>
+    public sealed class UpdateExfiltrationPointPacket : BasePacket
+    {
+        public string PointName;
+        public EFT.Interactive.EExfiltrationStatus Command;
+        public List<string> QueuedPlayers;
+
+        public UpdateExfiltrationPointPacket() : base(nameof(UpdateExfiltrationPointPacket)) {}
+
+        public override byte[] Serialize()
+        {
+            var ms = new MemoryStream();
+            using BinaryWriter writer = new BinaryWriter(ms);
+            WriteHeader(writer);
+            writer.Write(PointName);
+            writer.Write((byte)Command);
+            writer.Write((byte)QueuedPlayers.Count);
+            foreach (var p in QueuedPlayers)
+            {
+                writer.Write(p);
+            }
+            return ms.ToArray();
+        }
+
+        public override ISITPacket Deserialize(byte[] bytes)
+        {
+            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));
+            ReadHeader(reader);
+            PointName = reader.ReadString();
+            Command = (EFT.Interactive.EExfiltrationStatus)reader.ReadByte();
+            byte count = reader.ReadByte();
+            QueuedPlayers = new(count);
+            for (int i = 0; i < count; i++)
+            {
+                QueuedPlayers.Add(reader.ReadString());
+            }
+            return this;
+        }
+        public override void Process()
+        {
+            var point = ExfiltrationControllerClass.Instance.ExfiltrationPoints.First(x => x.Settings.Name == PointName);
+            if (point == null)
+            {
+                return;
+            }
+
+            ExfiltrationControllerClass.Instance.UpdatePoint(PointName, Command, QueuedPlayers);
+        }
+    }
+}

--- a/Source/Coop/SITGameModes/ISITGame.cs
+++ b/Source/Coop/SITGameModes/ISITGame.cs
@@ -7,6 +7,7 @@
 using Comfort.Common;
 using EFT;
 using EFT.Bots;
+using EFT.Interactive;
 using StayInTarkov.Networking;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -23,6 +24,14 @@ namespace StayInTarkov.Coop.SITGameModes
         public bool HostReady { get; set; }
 
         Dictionary<string, (float, long, string)> ExtractingPlayers { get; }
+
+        /// <summary>
+        /// ExfiltrationPoints that have started counting down. They will extract all Entered players upon reaching 0
+        /// They will be disabled if not reusable
+        /// </summary>
+        public List<ExfiltrationPoint> EnabledCountdownExfils { get; }
+
+        public float PastTime { get; }
 
         ExitStatus MyExitStatus { get; set; }
 

--- a/Source/Coop/SITGameModes/MultiplayerSITGame.cs
+++ b/Source/Coop/SITGameModes/MultiplayerSITGame.cs
@@ -6,6 +6,7 @@
 using Comfort.Common;
 using EFT;
 using EFT.Bots;
+using EFT.Interactive;
 using EFT.Weather;
 using StayInTarkov.Networking;
 using System;
@@ -23,6 +24,10 @@ namespace StayInTarkov.Coop.SITGameModes
         public List<string> ExtractedPlayers => throw new NotImplementedException();
 
         public Dictionary<string, (float, long, string)> ExtractingPlayers => throw new NotImplementedException();
+
+        public List<ExfiltrationPoint> EnabledCountdownExfils => throw new NotImplementedException();
+
+        public float PastTime => throw new NotImplementedException();
 
         public ExitStatus MyExitStatus { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string MyExitLocation { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/Source/StayInTarkovHelperConstants.cs
+++ b/Source/StayInTarkovHelperConstants.cs
@@ -190,7 +190,7 @@ namespace StayInTarkov
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 Error = (serializer, err) =>
                 {
-                    Logger.LogError(err.ErrorContext.Error.ToString());
+                    Logger.LogError($"JsonSerializer.Error {err.ErrorContext.Error}");
                 }
             };
         }


### PR DESCRIPTION
This adds live-like car extracts where:
- once a player pays the 5000 roubles, the car extract is enabled and will leave 1min later for all players
- leaving and entering the exfil area does not reset the timer
- more players can pay to be part of the extraction
- once the car has left, the exfil is not usable anymore

In code, the following needed to happen to make it work:
- when a client changes the exfil point, all other clients need to know and set the correct exfil start time. We use a packet inspired by live for that
- each client has to handle their own extraction, as `exfilpoint.Entered` is local because the physics/collision check is local