### PR TITLE
Replace Trigger Press with Initiate Shot

### DIFF
--- a/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
@@ -267,5 +267,14 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
             GameClient.SendData(packet.Serialize());
             return base.ToggleLauncher();
         }
+
+        public override void CreateFlareShot(BulletClass flareItem, Vector3 shotPosition, Vector3 forward)
+        {
+            var createFlareShotPacket = new CreateFlareShotPacket(_player.ProfileId, shotPosition, forward, flareItem.TemplateId);
+            GameClient.SendData(createFlareShotPacket.Serialize());
+
+            base.CreateFlareShot(flareItem, shotPosition, forward);
+        }
+
     }
 }

--- a/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx.Logging;
 using Comfort.Common;
+using EFT;
 using EFT.InventoryLogic;
 using EFT.UI;
 using StayInTarkov.Coop.NetworkPacket.Player.Weapons;
@@ -10,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace StayInTarkov.Coop.Controllers.HandControllers
 {
@@ -188,24 +190,62 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
             base.SetScopeMode(scopeStates);
         }
 
-        public override void SetTriggerPressed(bool pressed)
+        //public override void SetTriggerPressed(bool pressed)
+        //{
+        //    TriggerPressedPacket packet = new TriggerPressedPacket(_player.ProfileId);
+        //    packet.Pressed = pressed;
+        //    packet.RotationX = _player.Rotation.x;
+        //    packet.RotationY = _player.Rotation.y;
+
+        //    // TODO: After release, sync amount of bullets used
+        //    if (!pressed)
+        //    {
+        //    }
+
+        //    GameClient.SendData(packet.Serialize());
+
+        //    ((CoopPlayer)_player).TriggerPressed = pressed;
+
+        //    base.SetTriggerPressed(pressed);
+
+        //}
+
+        public override void InitiateShot(IWeapon weapon, BulletClass ammo, Vector3 shotPosition, Vector3 shotDirection, Vector3 fireportPosition, int chamberIndex, float overheat)
         {
-            TriggerPressedPacket packet = new TriggerPressedPacket(_player.ProfileId);
-            packet.Pressed = pressed;
-            packet.RotationX = _player.Rotation.x;
-            packet.RotationY = _player.Rotation.y;
-
-            // TODO: After release, sync amount of bullets used
-            if (!pressed)
+            EShotType shotType = EShotType.Unknown;
+            switch (weapon.MalfState.State)
             {
+                case Weapon.EMalfunctionState.None:
+                    shotType = EShotType.RegularShot;
+                    break;
+                case Weapon.EMalfunctionState.Misfire:
+                    shotType = EShotType.Misfire;
+                    break;
+                case Weapon.EMalfunctionState.Jam:
+                    shotType = EShotType.JamedShot;
+                    break;
+                case Weapon.EMalfunctionState.HardSlide:
+                    shotType = EShotType.HardSlidedShot;
+                    break;
+                case Weapon.EMalfunctionState.SoftSlide:
+                    shotType = EShotType.SoftSlidedShot;
+                    break;
+                case Weapon.EMalfunctionState.Feed:
+                    shotType = EShotType.Feed;
+                    break;
             }
-
-            GameClient.SendData(packet.Serialize());
-
-            ((CoopPlayer)_player).TriggerPressed = pressed;
-
-            base.SetTriggerPressed(pressed);
-
+            InitiateShotPacket initiateShotPacket = new InitiateShotPacket(_player.ProfileId);
+            initiateShotPacket.IsPrimaryActive = (weapon == base.Item);
+            initiateShotPacket.ShotType = shotType;
+            initiateShotPacket.ShotPosition = shotPosition;
+            initiateShotPacket.ShotDirection = shotDirection;
+            initiateShotPacket.FireportPosition = fireportPosition;
+            initiateShotPacket.AmmoAfterShot = weapon.GetCurrentMagazineCount();
+            initiateShotPacket.ChamberIndex = chamberIndex;
+            initiateShotPacket.Overheat = overheat;
+            initiateShotPacket.UnderbarrelShot = weapon.IsUnderbarrelWeapon;
+            GameClient.SendData(initiateShotPacket.Serialize());
+            base.InitiateShot(weapon, ammo, shotPosition, shotDirection, fireportPosition, chamberIndex, overheat);
         }
 
         public override void IEventsConsumerOnFiringBullet()

--- a/Source/Coop/Controllers/HandControllers/SITFirearmControllerAI.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmControllerAI.cs
@@ -11,5 +11,14 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
     public sealed class SITFirearmControllerAI : SITFirearmController
     {
         public override Vector3 WeaponDirection => _player.LookDirection;
+
+        public override void InitiateShot(IWeapon weapon, BulletClass ammo, Vector3 shotPosition, Vector3 shotDirection, Vector3 fireportPosition, int chamberIndex, float overheat)
+        {
+            overheat = 0;
+            Malfunction = false;
+            base.InitiateShot(weapon, ammo, shotPosition, shotDirection, fireportPosition, chamberIndex, overheat);
+            overheat = 0;
+            Malfunction = false;
+        }
     }
 }

--- a/Source/Coop/Controllers/HandControllers/SITFirearmControllerClient.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmControllerClient.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace StayInTarkov.Coop.Controllers.HandControllers
 {
@@ -129,5 +130,13 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
             return base.ToggleLauncher();
         }
 
+        public void PlaySounds(WeaponSoundPlayer weaponSoundPlayer, BulletClass ammo, Vector3 shotPosition, Vector3 shotDirection, bool multiShot)
+        {
+            if (Item.FireMode.FireMode != Weapon.EFireMode.burst || Item.FireMode.BurstShotsCount != 2 || IsBirstOf2Start || Item.ChamberAmmoCount <= 0)
+            {
+                float pitchMult = method_55();
+                weaponSoundPlayer.FireBullet(ammo, shotPosition, shotDirection.normalized, pitchMult, Malfunction, multiShot, IsBirstOf2Start);
+            }
+        }
     }
 }

--- a/Source/Coop/Controllers/HandControllers/SITFirearmControllerClient.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmControllerClient.cs
@@ -138,5 +138,7 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
                 weaponSoundPlayer.FireBullet(ammo, shotPosition, shotDirection.normalized, pitchMult, Malfunction, multiShot, IsBirstOf2Start);
             }
         }
+
+        
     }
 }

--- a/Source/Coop/NetworkPacket/Player/Weapons/CreateFlareShotPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/CreateFlareShotPacket.cs
@@ -1,0 +1,82 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.InventoryLogic;
+using StayInTarkov.Coop.Controllers.HandControllers;
+using StayInTarkov.Coop.Players;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static StayInTarkov.Networking.SITSerialization;
+
+namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons
+{
+    public sealed class CreateFlareShotPacket : BasePlayerPacket
+    {
+
+        public Vector3 ShotPosition { get; set; }
+
+        public Vector3 ShotForward { get; set; }
+
+        public string FlareTemplateId { get; set; }
+
+
+        public CreateFlareShotPacket() : base("", nameof(CreateFlareShotPacket))
+        {
+        }
+
+        public CreateFlareShotPacket(string profileId, Vector3 shotPosition, Vector3 shotForward, string flareTpl) : base(profileId, nameof(CreateFlareShotPacket))
+        {
+            this.ShotPosition = shotPosition;
+            this.ShotForward = shotForward;
+            this.FlareTemplateId = flareTpl;
+        }
+
+        public override byte[] Serialize()
+        {
+            var ms = new MemoryStream();
+            using BinaryWriter writer = new BinaryWriter(ms);
+            WriteHeaderAndProfileId(writer);
+            Vector3Utils.Serialize(writer, ShotPosition);
+            Vector3Utils.Serialize(writer, ShotForward);
+            writer.Write(FlareTemplateId);
+            return ms.ToArray();
+        }
+
+        public override ISITPacket Deserialize(byte[] bytes)
+        {
+            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));  
+            ReadHeaderAndProfileId(reader);
+            ShotPosition = Vector3Utils.Deserialize(reader);
+            ShotForward = Vector3Utils.Deserialize(reader);
+            FlareTemplateId = reader.ReadString();
+            return this;
+        }
+
+        protected override void Process(CoopPlayerClient client)
+        {
+            StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(CreateFlareShotPacket)}.{nameof(Process)}(client)");
+
+            if (client.HandsController is SITFirearmControllerClient firearmControllerClient)
+            {
+                StayInTarkovHelperConstants.Logger.LogInfo(firearmControllerClient);
+                StayInTarkovHelperConstants.Logger.LogInfo(firearmControllerClient.Weapon);
+                MagazineClass currentMagazine = firearmControllerClient.Weapon.GetCurrentMagazine();
+                if (currentMagazine != null)
+                {
+                    StayInTarkovHelperConstants.Logger.LogInfo(currentMagazine);
+
+                }
+                //var pic = ItemFinder.GetPlayerInventoryController(client);
+
+                BulletClass flareItem = (BulletClass)Singleton<ItemFactory>.Instance.CreateItem(MongoID.Generate(), this.FlareTemplateId, null);
+                firearmControllerClient.InitiateFlare(flareItem, this.ShotPosition, this.ShotForward);
+            }
+        }
+
+    }
+}

--- a/Source/Coop/NetworkPacket/Player/Weapons/CreateFlareShotPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/CreateFlareShotPacket.cs
@@ -1,4 +1,9 @@
-﻿using Comfort.Common;
+﻿/**
+ * This file is written and licensed by Paulov (https://github.com/paulov-t) for Stay in Tarkov (https://github.com/stayintarkov)
+ * You are not allowed to reproduce this file in any other project
+ */
+
+using Comfort.Common;
 using EFT;
 using EFT.InventoryLogic;
 using StayInTarkov.Coop.Controllers.HandControllers;

--- a/Source/Coop/NetworkPacket/Player/Weapons/InitiateShotPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/InitiateShotPacket.cs
@@ -1,0 +1,182 @@
+﻿using EFT;
+using EFT.InventoryLogic;
+using EFT.UI;
+using GPUInstancer;
+using StayInTarkov.Coop.Controllers.HandControllers;
+using StayInTarkov.Coop.Players;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static StayInTarkov.Networking.SITSerialization;
+
+namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons
+{
+    public sealed class InitiateShotPacket : BasePlayerPacket
+    {
+        public bool IsPrimaryActive { get; set; }
+
+        public int AmmoAfterShot { get; set; }
+
+        public EShotType ShotType { get; set; }
+
+        public Vector3 ShotPosition { get; set; }
+
+        public Vector3 ShotDirection { get; set; }
+
+        public Vector3 FireportPosition { get; set; }
+
+        public int ChamberIndex { get; set; }
+
+        public float Overheat { get; set; }
+
+        public bool UnderbarrelShot { get; set; }
+
+        public InitiateShotPacket()
+        {
+        }
+
+        public InitiateShotPacket(string profileId) : base(new string(profileId.ToCharArray()), nameof(InitiateShotPacket))
+        {
+        }
+
+        public override byte[] Serialize()
+        {
+            var ms = new MemoryStream();
+            using BinaryWriter writer = new BinaryWriter(ms);
+            WriteHeaderAndProfileId(writer);
+            writer.Write(IsPrimaryActive);
+            writer.Write(AmmoAfterShot);
+            writer.Write((byte)ShotType);
+            Vector3Utils.Serialize(writer, ShotPosition);
+            Vector3Utils.Serialize(writer, ShotDirection);
+            Vector3Utils.Serialize(writer, FireportPosition);
+            writer.Write(ChamberIndex);
+            writer.Write(Overheat);
+            writer.Write(UnderbarrelShot);
+            return ms.ToArray();
+        }
+
+        public override ISITPacket Deserialize(byte[] bytes)
+        {
+            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));  
+            ReadHeaderAndProfileId(reader);
+            IsPrimaryActive = reader.ReadBoolean();
+            AmmoAfterShot = reader.ReadInt32();
+            ShotType = (EShotType)reader.ReadByte();
+            ShotPosition = Vector3Utils.Deserialize(reader);
+            ShotDirection = Vector3Utils.Deserialize(reader);
+            FireportPosition = Vector3Utils.Deserialize(reader);
+            ChamberIndex = reader.ReadInt32();
+            Overheat = reader.ReadSingle();
+            UnderbarrelShot = reader.ReadBoolean();
+            return this;
+
+        }
+
+        protected override void Process(CoopPlayerClient client)
+        {
+            if(client.HandsController is SITFirearmControllerClient firearmControllerClient)
+            {
+                GetBulletToFire(client, firearmControllerClient.Weapon, out var ammoToFire, out int countInMag);
+                if (ammoToFire == null)
+                {
+                    StayInTarkovHelperConstants.Logger.LogError($"Unable to find Ammo for {firearmControllerClient.Weapon.Name}");
+                    return;
+                }
+                ammoToFire.IsUsed = true;
+                switch (ShotType)
+                {
+                    case EShotType.DryFire:
+                        firearmControllerClient.DryShot(ChamberIndex, UnderbarrelShot);
+                        break;
+                    case EShotType.Misfire:
+                    case EShotType.Feed:
+                    case EShotType.JamedShot:
+                    case EShotType.SoftSlidedShot:
+                    case EShotType.HardSlidedShot:
+                        firearmControllerClient.Weapon.MalfState.MalfunctionedAmmo = ammoToFire;
+                        WeaponPrefab component = firearmControllerClient.ControllerGameObject.GetComponent<WeaponPrefab>();
+                        if (component != null)
+                        {
+                            component.InitMalfunctionState(firearmControllerClient.Weapon, hasPlayer: false, malfunctionKnown: false, out var _);
+                        }
+                        switch (ShotType)
+                        {
+                            case EShotType.Misfire:
+                                firearmControllerClient.Weapon.MalfState.State = Weapon.EMalfunctionState.Misfire;
+                                break;
+                            case EShotType.Feed:
+                                firearmControllerClient.Weapon.MalfState.State = Weapon.EMalfunctionState.Feed;
+                                break;
+                            case EShotType.JamedShot:
+                                firearmControllerClient.Weapon.MalfState.State = Weapon.EMalfunctionState.Jam;
+                                break;
+                            case EShotType.SoftSlidedShot:
+                                firearmControllerClient.Weapon.MalfState.State = Weapon.EMalfunctionState.SoftSlide;
+                                break;
+                            case EShotType.HardSlidedShot:
+                                firearmControllerClient.Weapon.MalfState.State = Weapon.EMalfunctionState.HardSlide;
+                                break;
+                        }
+                        break;
+                    case EShotType.RegularShot:
+                        firearmControllerClient.InitiateShot(firearmControllerClient.Weapon, ammoToFire, ShotPosition, ShotDirection, FireportPosition, ChamberIndex, Overheat);
+                        firearmControllerClient.PlaySounds(firearmControllerClient.WeaponSoundPlayer, ammoToFire, ShotPosition, ShotDirection, false);
+
+                        if (firearmControllerClient.Weapon.IsBoltCatch && firearmControllerClient.Weapon.ChamberAmmoCount == 0 && firearmControllerClient.Weapon.GetCurrentMagazineCount() == 0 && !firearmControllerClient.Weapon.ManualBoltCatch)
+                        {
+                            firearmControllerClient.FirearmsAnimator.SetBoltCatch(active: true);
+                        }
+                        else if (firearmControllerClient.Weapon.IsBoltCatch && !firearmControllerClient.Weapon.ManualBoltCatch && firearmControllerClient.FirearmsAnimator.GetBoltCatch())
+                        {
+                            firearmControllerClient.FirearmsAnimator.SetBoltCatch(active: false);
+                        }
+                        if (firearmControllerClient.Weapon.BoltAction)
+                        {
+                            firearmControllerClient.FirearmsAnimator.SetBoltActionReload(boltActionReload: true);
+                            firearmControllerClient.FirearmsAnimator.SetFire(fire: true);
+                            firearmControllerClient.StartCoroutine(DisableBoltActionAnim(firearmControllerClient));
+                        }
+
+                        break;
+                    default:
+                        break;
+                }
+
+            }
+        }
+
+        private IEnumerator DisableBoltActionAnim(SITFirearmControllerClient client)
+        {
+            yield return new WaitForSeconds(0.5f);
+            client.FirearmsAnimator.SetBoltActionReload(boltActionReload: false);
+            client.FirearmsAnimator.SetFire(fire: false);
+        }
+
+        private void GetBulletToFire(CoopPlayerClient client, Weapon weapon_0, out BulletClass ammoToFire, out int ammoCountInMagBeforeShot)
+        {
+            var pic = ItemFinder.GetPlayerInventoryController(client);
+            Slot[] chambers = weapon_0.Chambers;
+            ammoToFire = (weapon_0.HasChambers ? chambers[0] : null)?.ContainedItem as BulletClass;
+            MagazineClass currentMagazine = weapon_0.GetCurrentMagazine();
+            if (currentMagazine == null)
+            {
+                ammoCountInMagBeforeShot = 0;
+                return;
+            }
+            ammoCountInMagBeforeShot = currentMagazine.Count;
+            if (currentMagazine.IsAmmoCompatible(chambers) && ammoCountInMagBeforeShot > 0)
+            {
+                ammoToFire = (BulletClass)currentMagazine.Cartridges.PopToNowhere(pic).Value.Item;
+            }
+        }
+
+       
+    }
+}

--- a/Source/Coop/NetworkPacket/Player/Weapons/InitiateShotPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/InitiateShotPacket.cs
@@ -1,4 +1,9 @@
-﻿using BepInEx.Logging;
+﻿/**
+ * This file is written and licensed by Paulov (https://github.com/paulov-t) for Stay in Tarkov (https://github.com/stayintarkov)
+ * You are not allowed to reproduce this file in any other project
+ */
+
+using BepInEx.Logging;
 using EFT;
 using EFT.InventoryLogic;
 using EFT.UI;

--- a/Source/Coop/NetworkPacket/Player/Weapons/TriggerPressedPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/TriggerPressedPacket.cs
@@ -1,69 +1,69 @@
-﻿using EFT;
-using EFT.InventoryLogic;
-using StayInTarkov.Coop.Components.CoopGameComponents;
-using StayInTarkov.Coop.NetworkPacket.Player.Proceed;
-using StayInTarkov.Coop.Players;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityStandardAssets.Water;
+﻿//using EFT;
+//using EFT.InventoryLogic;
+//using StayInTarkov.Coop.Components.CoopGameComponents;
+//using StayInTarkov.Coop.NetworkPacket.Player.Proceed;
+//using StayInTarkov.Coop.Players;
+//using System;
+//using System.Collections.Generic;
+//using System.IO;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
+//using UnityStandardAssets.Water;
 
-namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons
-{
-    public sealed class TriggerPressedPacket : BasePlayerPacket
-    {
-        public bool Pressed { get; set; }
-        public float RotationX { get; set; }
-        public float RotationY { get; set; }
+//namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons
+//{
+//    public sealed class TriggerPressedPacket : BasePlayerPacket
+//    {
+//        public bool Pressed { get; set; }
+//        public float RotationX { get; set; }
+//        public float RotationY { get; set; }
 
-        public TriggerPressedPacket() { }
+//        public TriggerPressedPacket() { }
 
-        public TriggerPressedPacket(string profileId) : base(new string(profileId.ToCharArray()), nameof(TriggerPressedPacket))
-        {
-        }
+//        public TriggerPressedPacket(string profileId) : base(new string(profileId.ToCharArray()), nameof(TriggerPressedPacket))
+//        {
+//        }
 
-        public override byte[] Serialize()
-        {
-            var ms = new MemoryStream();
-            using BinaryWriter writer = new BinaryWriter(ms);
-            WriteHeaderAndProfileId(writer);
-            writer.Write(Pressed);
-            writer.Write(RotationX);
-            writer.Write(RotationY);
-            writer.Write(TimeSerializedBetter);
+//        public override byte[] Serialize()
+//        {
+//            var ms = new MemoryStream();
+//            using BinaryWriter writer = new BinaryWriter(ms);
+//            WriteHeaderAndProfileId(writer);
+//            writer.Write(Pressed);
+//            writer.Write(RotationX);
+//            writer.Write(RotationY);
+//            writer.Write(TimeSerializedBetter);
 
-            return ms.ToArray();
-        }
+//            return ms.ToArray();
+//        }
 
-        public override ISITPacket Deserialize(byte[] bytes)
-        {
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes));
+//        public override ISITPacket Deserialize(byte[] bytes)
+//        {
+//            if (bytes == null)
+//                throw new ArgumentNullException(nameof(bytes));
 
-            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));
-            ReadHeaderAndProfileId(reader);
-            Pressed = reader.ReadBoolean();
-            RotationX = reader.ReadSingle();
-            RotationY = reader.ReadSingle();
-            TimeSerializedBetter = reader.ReadString();
+//            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));
+//            ReadHeaderAndProfileId(reader);
+//            Pressed = reader.ReadBoolean();
+//            RotationX = reader.ReadSingle();
+//            RotationY = reader.ReadSingle();
+//            TimeSerializedBetter = reader.ReadString();
 
-            return this;
-        }
+//            return this;
+//        }
 
-        protected override void Process(CoopPlayerClient client)
-        {
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-            {
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-                if (client.HandsController is EFT.Player.FirearmController fc)
-                {
-                    fc.SetTriggerPressed(Pressed);
-                }
-            }
-        }
+//        protected override void Process(CoopPlayerClient client)
+//        {
+//            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+//            {
+//                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
+//                if (client.HandsController is EFT.Player.FirearmController fc)
+//                {
+//                    fc.SetTriggerPressed(Pressed);
+//                }
+//            }
+//        }
 
-    }
-}
+//    }
+//}


### PR DESCRIPTION
- Replaces the replicated Trigger Press command with a Firearm Controller Initiate Shot. This allows all clients to always shoot the same amount of bullets and replicate malfunctions.
- Adds replicated Flare