### PR TITLE
[fix] only call packet.process as client

### DIFF
--- a/Source/Networking/GameServerUDP.cs
+++ b/Source/Networking/GameServerUDP.cs
@@ -112,7 +112,6 @@ namespace StayInTarkov.Networking
         {
             //Logger.LogInfo("[Server] OnNetworkReceive");
             var bytes = reader.GetRemainingBytes();
-            SITGameServerClientDataProcessing.ProcessPacketBytes(bytes, Encoding.UTF8.GetString(bytes));
             _netServer.SendToAll(bytes, deliveryMethod);
 
 #if DEBUG


### PR DESCRIPTION
- UDP server always fans out packets to all connected clients
- The player hosting is running both UDP server and UDP client. As a client, it will receive the fanned out packets
- We do not need to process packets server-side since the same packets will be processed client-side in `INetEventListener.OnNetworkReceive`

Observed locally that the exact same packet are processed twice when hosting.

EDIT: everything works fine after more testing