### PR TITLE
fix door unlock freezing player

### DIFF
--- a/Source/Coop/NetworkPacket/Player/PlayerInteractWithDoorPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/PlayerInteractWithDoorPacket.cs
@@ -104,7 +104,7 @@ namespace StayInTarkov.Coop.NetworkPacket.Player
             }
 
             // Interact with the door
-            client.vmethod_1(worldInteractiveObject, interactionResult);
+            client.vmethod_1(worldInteractiveObject, keyInteractionResult ?? interactionResult);
         }
 
 

--- a/Source/Coop/NetworkPacket/Player/PlayerInteractWithObjectPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/PlayerInteractWithObjectPacket.cs
@@ -99,7 +99,7 @@ namespace StayInTarkov.Coop.NetworkPacket.Player
             }
 
 
-            client.vmethod_0(worldInteractiveObject, interactionResult, () => { });
+            client.vmethod_0(worldInteractiveObject, keyInteractionResult ?? interactionResult, () => { });
         }
 
 


### PR DESCRIPTION
Other players would see the unlocking player frozen and hovering.

```
InvalidCastException: Specified cast is not valid.
  at BaseState.BaseUpdate () [0x00060] in <305d2033b20e43a1983675b0792a75c5>:0 
  at BaseState.ManualAnimatorMoveUpdate (System.Single deltaTime) [0x00019] in <305d2033b20e43a1983675b0792a75c5>:0 
  at EFT.MovementState.OnStateMove (System.Single normalizedTime) [0x00055] in <305d2033b20e43a1983675b0792a75c5>:0 
  at PlayerStateContainer.OnStateMove (UnityEngine.Animator animator, UnityEngine.AnimatorStateInfo stateInfo, System.Int32 layerIndex) [0x00012] in <305d2033b20e43a1983675b0792a75c5>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
LogHandler:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
```