### PR TITLE
Fix airdrop container only can open for once

### DIFF
--- a/Source/Coop/Airdrops/SITAirdropsManager.cs
+++ b/Source/Coop/Airdrops/SITAirdropsManager.cs
@@ -4,6 +4,7 @@ using BepInEx.Logging;
 using Comfort.Common;
 using EFT;
 using EFT.Game.Spawning;
+using EFT.Interactive;
 using StayInTarkov;
 using StayInTarkov.AkiSupport.Airdrops;
 using StayInTarkov.AkiSupport.Airdrops.Models;
@@ -146,6 +147,17 @@ namespace Aki.Custom.Airdrops
 
                 factory.BuildContainer(AirdropBox.Container, ClientAirdropConfigModel, ClientAirdropLootResultModel.DropType);
                 factory.AddLoot(AirdropBox.Container, ClientAirdropLootResultModel);
+                if (AirdropBox.Container != null)
+                {
+                    if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                    {
+                        List<WorldInteractiveObject> oldInteractiveObjectList = new List<WorldInteractiveObject>(coopGameComponent.ListOfInteractiveObjects)
+                        {
+                            AirdropBox.Container
+                        };
+                        coopGameComponent.ListOfInteractiveObjects = [.. oldInteractiveObjectList];
+                    }
+                }
             }
 
             if (!ClientLootBuilt)
@@ -244,6 +256,17 @@ namespace Aki.Custom.Airdrops
             factory.BuildContainer(AirdropBox.Container, config, lootData.DropType);
             factory.AddLoot(AirdropBox.Container, lootData);
             ClientLootBuilt = true;
+            if (AirdropBox.Container != null)
+            {
+                if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                {
+                    List<WorldInteractiveObject> oldInteractiveObjectList = new List<WorldInteractiveObject>(coopGameComponent.ListOfInteractiveObjects)
+                    {
+                        AirdropBox.Container
+                    };
+                    coopGameComponent.ListOfInteractiveObjects = [.. oldInteractiveObjectList];
+                }
+            }
         }
 
         public void ReceiveBuildLootContainer(AirdropLootResultModel lootData, AirdropConfigModel config)


### PR DESCRIPTION
Fix airdrop container only can open for once.
Now you can reopen the airdrop container

Showcase (Different raid time):
![ac1](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/30b8c048-d761-410c-97ea-e8fb0144e697)
![ac2](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/c4537463-6d71-47ea-9b88-30e987a1355c)
![ac3](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/5b7fe10c-68c3-475d-8ee6-97c388e346e6)
![ac4](https://github.com/stayintarkov/StayInTarkov.Client/assets/30657653/d371fbdc-117c-4c07-8f9e-b987f72b72df)
