### PR TITLE
fix chance-based exfils not in sync

### DIFF
--- a/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
@@ -36,6 +36,7 @@ using Diz.Jobs;
 using System.Net.NetworkInformation;
 using EFT.Counters;
 using StayInTarkov.AkiSupport.Singleplayer.Utils.InRaid;
+using StayInTarkov.Coop.NetworkPacket.World;
 
 namespace StayInTarkov.Coop.Components.CoopGameComponents
 {
@@ -362,10 +363,26 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
             StartCoroutine(SendPlayerStatePacket());
 
+            // tell clients which exfils are disabled
+            if (SITMatchmaking.IsServer)
+            {
+                foreach (var point in ExfiltrationControllerClass.Instance.ExfiltrationPoints)
+                {
+                    if (point.Status == EExfiltrationStatus.NotPresent)
+                    {
+                        UpdateExfiltrationPointPacket packet = new()
+                        {
+                            PointName = point.Settings.Name,
+                            Command = point.Status,
+                            QueuedPlayers = point.QueuedPlayers
+                        };
+                        GameClient.SendData(packet.Serialize());
+                    }
+                }
+            }
 
             // Get a List of Interactive Objects (this is a slow method), so run once here to maintain a reference
             ListOfInteractiveObjects = FindObjectsOfType<WorldInteractiveObject>();
-
         }
 
         /// <summary>

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -1246,7 +1246,7 @@ namespace StayInTarkov.Coop.SITGameModes
 
                 //Logger.LogDebug(InfiltrationPoint);
 
-                ExfiltrationControllerClass.Instance.InitAllExfiltrationPoints(Location_0.exits, justLoadSettings: false, "");
+                ExfiltrationControllerClass.Instance.InitAllExfiltrationPoints(Location_0.exits, justLoadSettings: SITMatchmaking.IsClient, "");
                 ExfiltrationPoint[] exfilPoints = ExfiltrationControllerClass.Instance.EligiblePoints(Profile_0);
                 GameUi.TimerPanel.SetTime(DateTime.UtcNow, Profile_0.Info.Side, GameTimer.SessionSeconds(), exfilPoints);
                 foreach (ExfiltrationPoint exfiltrationPoint in exfilPoints)
@@ -1600,10 +1600,12 @@ namespace StayInTarkov.Coop.SITGameModes
                 FPSCamera.Instance.SetOcclusionCullingEnabled(Location_0.OcculsionCullingEnabled);
                 FPSCamera.Instance.IsActive = false;
             }
+
             await SpawnLoot(location);
             await WaitForPlayersToSpawn();
             await WaitForPlayersToBeReady();
             await WaitForHostToStart();
+
             method_5(botsSettings, SpawnSystem, runCallback);
         }
 


### PR DESCRIPTION
Noticed chance-based exfils (e.g. Dorms V-Ex, Smuggler Boat, etc.) were not synced across players while working on the car extract patch. This is due to the random seed being local to each client.

This patch tells clients to just load exfil settings and wait for server's decision as to which ones should be disabled.