### PR TITLE
Remove [TEST], "ASM" and "EXE" from Version Label

### DIFF
--- a/Source/EssentialPatches/VersionLabelPatch.cs
+++ b/Source/EssentialPatches/VersionLabelPatch.cs
@@ -86,7 +86,7 @@ namespace StayInTarkov.EssentialPatches
                     Logger.LogInfo($"Assembly {StayInTarkovPlugin.EFTAssemblyVersion} does not match {StayInTarkovPlugin.EFTEXEFileVersion}");
                 }
                 else
-                    _versionLabel = $"SIT {sitversion} [TEST] | ASM {StayInTarkovPlugin.EFTAssemblyVersion} | EXE {StayInTarkovPlugin.EFTEXEFileVersion}";
+                    _versionLabel = $"SIT {sitversion} | {StayInTarkovPlugin.EFTAssemblyVersion}";
             }
 
             Traverse.Create(MonoBehaviourSingleton<PreloaderUI>.Instance).Field("_alphaVersionLabel").Property("LocalizationKey").SetValue("{0}");


### PR DESCRIPTION
- Removes [TEST]
- Removes "ASM" and "EXE"
- Removes the "EXE" version label