### PR TITLE
refactor ping system + add down/up speeds

### DIFF
--- a/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
@@ -51,8 +51,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
         public SITConfig SITConfig { get; private set; } = new SITConfig();
         public string ServerId { get; set; } = null;
         public long Timestamp { get; set; } = 0;
-
-        public EFT.Player OwnPlayer { get; set; }
+        public ushort AkiBackendPing = 0;
 
         /// <summary>
         /// ProfileId to Player instance
@@ -63,7 +62,6 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
         /// The Client Drones connected to this Raid
         /// </summary>
         public HashSet<CoopPlayerClient> PlayerClients { get; } = new();
-
 
         //public EFT.Player[] PlayerUsers
         public IEnumerable<EFT.Player> PlayerUsers
@@ -243,39 +241,18 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             // Enable the Coop Patches
             CoopPatches.EnableDisablePatches();
 
-            Singleton<GameWorld>.Instance.AfterGameStarted += GameWorld_AfterGameStarted;
+            Singleton<GameWorld>.Instance.AfterGameStarted += GameWorld_AfterGameStarted;;
 
             // In game ping system.
             if (Singleton<FrameMeasurer>.Instantiated)
             {
+                var rttMs = 2 * (Singleton<IGameClient>.Instance?.Ping ?? 1);
                 FrameMeasurer instance = Singleton<FrameMeasurer>.Instance;
-                instance.PlayerRTT = ServerPing;
-                instance.ServerFixedUpdateTime = ServerPing;
-                instance.ServerTime = ServerPing;
+                instance.PlayerRTT = rttMs;
+                instance.ServerFixedUpdateTime = rttMs;
+                instance.ServerTime = rttMs;
                 instance.NetworkQuality.CreateMeasurers();
             }
-
-
-            //System.Net.NetworkInformation.Ping pingSender = new ();
-            //PingOptions options = new PingOptions();
-
-            //// Use the default Ttl value which is 128,
-            //// but change the fragmentation behavior.
-            //options.DontFragment = true;
-
-            //// Create a buffer of 32 bytes of data to be transmitted.
-            //string data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-            //byte[] buffer = Encoding.ASCII.GetBytes(data);
-            //int timeout = 120;
-            //PingReply reply = pingSender.Send(args[0], timeout, buffer, options);
-            //if (reply.Status == IPStatus.Success)
-            //{
-            //    Console.WriteLine("Address: {0}", reply.Address.ToString());
-            //    Console.WriteLine("RoundTrip time: {0}", reply.RoundtripTime);
-            //    Console.WriteLine("Time to live: {0}", reply.Options.Ttl);
-            //    Console.WriteLine("Don't fragment: {0}", reply.Options.DontFragment);
-            //    Console.WriteLine("Buffer size: {0}", reply.Buffer.Length);
-            //}
         }
 
         private IEnumerator SendPlayerStatePacket()
@@ -520,10 +497,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                     }
                 }
 
-                if (Singleton<ISITGame>.Instance.GameClient is GameClientUDP udp)
-                {
-                    udp.ResetStats();
-                }
+                coopGame.GameClient.ResetStats();
             }
         }
 
@@ -1025,10 +999,11 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             // In game ping system.
             if (Singleton<FrameMeasurer>.Instantiated)
             {
+                var rttMs = 2 * (Singleton<IGameClient>.Instance?.Ping ?? 1);
                 FrameMeasurer instance = Singleton<FrameMeasurer>.Instance;
-                instance.PlayerRTT = ServerPing;
-                instance.ServerFixedUpdateTime = ServerPing;
-                instance.ServerTime = ServerPing;
+                instance.PlayerRTT = rttMs;
+                instance.ServerFixedUpdateTime = rttMs;
+                instance.ServerTime = rttMs;
                 //instance.NetworkQuality.CreateMeasurers();
             }
 
@@ -1674,369 +1649,11 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
         public BaseLocalGame<GamePlayerOwner> LocalGameInstance { get; internal set; }
 
-        int GuiX = 10;
-        int GuiWidth = 400;
-
-        //public const int PING_LIMIT_HIGH = 125;
-        //public const int PING_LIMIT_MID = 100;
-
-        public int ServerPing { get; private set; } = 1;
-        public ConcurrentQueue<int> ServerPingSmooth { get; } = new();
-
-        public void UpdatePing(int ms)
-        {
-            //Logger.LogDebug($"{nameof(UpdatePing)}:Updating with:{ms}");
-
-            if (ServerPingSmooth.Count > 60)
-                ServerPingSmooth.TryDequeue(out _);
-            ServerPingSmooth.Enqueue(ms);
-            ServerPing = ServerPingSmooth.Count > 0 ? (int)Math.Round(ServerPingSmooth.Average()) : 1;
-        }
-
         //public bool HighPingMode { get; set; } = false;
         public bool ServerHasStopped { get; set; }
         private bool ServerHasStoppedActioned { get; set; }
         public ConcurrentQueue<EFT.Player> PlayersForAIToTarget { get; } = new();
         public bool GameWorldGameStarted { get; private set; }
-
-        GUIStyle middleLabelStyle;
-        GUIStyle middleLargeLabelStyle;
-        GUIStyle normalLabelStyle;
-
-        //void OnGUI()
-        //{
-
-
-        //    if (normalLabelStyle == null)
-        //    {
-        //        normalLabelStyle = new GUIStyle(GUI.skin.label);
-        //        normalLabelStyle.fontSize = 16;
-        //        normalLabelStyle.fontStyle = FontStyle.Bold;
-        //    }
-        //    if (middleLabelStyle == null)
-        //    {
-        //        middleLabelStyle = new GUIStyle(GUI.skin.label);
-        //        middleLabelStyle.fontSize = 18;
-        //        middleLabelStyle.fontStyle = FontStyle.Bold;
-        //        middleLabelStyle.alignment = TextAnchor.MiddleCenter;
-        //    }
-        //    if (middleLargeLabelStyle == null)
-        //    {
-        //        middleLargeLabelStyle = new GUIStyle(middleLabelStyle);
-        //        middleLargeLabelStyle.fontSize = 24;
-        //    }
-
-        //    var rect = new Rect(GuiX, 5, GuiWidth, 100);
-        //    rect = DrawPing(rect);
-
-        //    GUIStyle style = GUI.skin.label;
-        //    style.alignment = TextAnchor.MiddleCenter;
-        //    style.fontSize = 13;
-
-        //    var w = 0.5f; // proportional width (0..1)
-        //    var h = 0.2f; // proportional height (0..1)
-        //    var rectEndOfGameMessage = Rect.zero;
-        //    rectEndOfGameMessage.x = (float)(Screen.width * (1 - w)) / 2;
-        //    rectEndOfGameMessage.y = (float)(Screen.height * (1 - h)) / 2 + Screen.height / 3;
-        //    rectEndOfGameMessage.width = Screen.width * w;
-        //    rectEndOfGameMessage.height = Screen.height * h;
-
-        //    var numberOfPlayersDead = PlayerUsers.Count(x => !x.HealthController.IsAlive);
-
-
-        //    if (LocalGameInstance == null)
-        //        return;
-
-        //    var coopGame = LocalGameInstance as CoopGame;
-        //    if (coopGame == null)
-        //        return;
-
-        //    rect = DrawSITStats(rect, numberOfPlayersDead, coopGame);
-
-        //    var quitState = GetQuitState();
-        //    switch (quitState)
-        //    {
-        //        case EQuitState.YourTeamIsDead:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_TEAM_DEAD"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YouAreDead:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_PLAYER_DEAD_SOLO"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YouAreDeadAsHost:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_PLAYER_DEAD_HOST"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YouAreDeadAsClient:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_PLAYER_DEAD_CLIENT"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YourTeamHasExtracted:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_TEAM_EXTRACTED"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YouHaveExtractedOnlyAsHost:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_PLAYER_EXTRACTED_HOST"], middleLargeLabelStyle);
-        //            break;
-        //        case EQuitState.YouHaveExtractedOnlyAsClient:
-        //            GUI.Label(rectEndOfGameMessage, StayInTarkovPlugin.LanguageDictionary["RAID_PLAYER_EXTRACTED_CLIENT"], middleLargeLabelStyle);
-        //            break;
-        //    }
-
-        //    //if(quitState != EQuitState.NONE)
-        //    //{
-        //    //    var rectEndOfGameButton = new Rect(rectEndOfGameMessage);
-        //    //    rectEndOfGameButton.y += 15;
-        //    //    if(GUI.Button(rectEndOfGameButton, "End Raid"))
-        //    //    {
-
-        //    //    }
-        //    //}
-
-
-        //    //OnGUI_DrawPlayerList(rect);
-        //    OnGUI_DrawPlayerFriendlyTags(rect);
-        //    //OnGUI_DrawPlayerEnemyTags(rect);
-
-        //}
-
-        private Rect DrawPing(Rect rect)
-        {
-            if (!PluginConfigSettings.Instance.CoopSettings.ShowPing)
-                return rect;
-
-            rect.y = 5;
-            GUI.Label(rect, $"SIT Coop: " + (SITMatchmaking.IsClient ? "CLIENT" : "SERVER"));
-            rect.y += 15;
-
-            // PING ------
-            GUI.contentColor = Color.white;
-            GUI.contentColor = ServerPing >= AkiBackendCommunication.PING_LIMIT_HIGH ? Color.red : ServerPing >= AkiBackendCommunication.PING_LIMIT_MID ? Color.yellow : Color.green;
-            GUI.Label(rect, $"RTT:{ServerPing}");
-            rect.y += 15;
-            GUI.Label(rect, $"Host RTT:{ServerPing + AkiBackendCommunication.Instance.HostPing}");
-            rect.y += 15;
-            GUI.contentColor = Color.white;
-
-            if (PerformanceCheck_ActionPackets)
-            {
-                GUI.contentColor = Color.red;
-                GUI.Label(rect, $"BAD PERFORMANCE!");
-                GUI.contentColor = Color.white;
-                rect.y += 15;
-            }
-
-            if (AkiBackendCommunication.Instance.HighPingMode)
-            {
-                GUI.contentColor = Color.red;
-                GUI.Label(rect, $"!HIGH PING MODE!");
-                GUI.contentColor = Color.white;
-                rect.y += 15;
-            }
-
-            return rect;
-        }
-
-        private Rect DrawSITStats(Rect rect, int numberOfPlayersDead, CoopSITGame coopGame)
-        {
-            if (!PluginConfigSettings.Instance.CoopSettings.SETTING_ShowSITStatistics)
-                return rect;
-
-            var numberOfPlayersAlive = PlayerUsers.Count(x => x.HealthController.IsAlive);
-            // gathering extracted
-            var numberOfPlayersExtracted = coopGame.ExtractedPlayers.Count;
-            GUI.Label(rect, $"Players (Alive): {numberOfPlayersAlive}");
-            rect.y += 15;
-            GUI.Label(rect, $"Players (Dead): {numberOfPlayersDead}");
-            rect.y += 15;
-            GUI.Label(rect, $"Players (Extracted): {numberOfPlayersExtracted}");
-            rect.y += 15;
-            GUI.Label(rect, $"Bots: {PlayerBots.Length}");
-            rect.y += 15;
-            return rect;
-        }
-
-        private void OnGUI_DrawPlayerFriendlyTags(Rect rect)
-        {
-            if (SITConfig == null)
-            {
-                Logger.LogError("SITConfig is null?");
-                return;
-            }
-
-            if (!SITConfig.showPlayerNameTags)
-            {
-                return;
-            }
-
-            if (FPSCamera.Instance == null)
-                return;
-
-            if (Players == null)
-                return;
-
-            if (PlayerUsers == null)
-                return;
-
-            if (Camera.current == null)
-                return;
-
-            if (!Singleton<GameWorld>.Instantiated)
-                return;
-
-
-            if (FPSCamera.Instance.SSAA != null && FPSCamera.Instance.SSAA.isActiveAndEnabled)
-                screenScale = FPSCamera.Instance.SSAA.GetOutputWidth() / (float)FPSCamera.Instance.SSAA.GetInputWidth();
-
-            var ownPlayer = Singleton<GameWorld>.Instance.MainPlayer;
-            if (ownPlayer == null)
-                return;
-
-            foreach (var pl in PlayerUsers)
-            {
-                if (pl == null)
-                    continue;
-
-                if (pl.HealthController == null)
-                    continue;
-
-                if (pl.IsYourPlayer && pl.HealthController.IsAlive)
-                    continue;
-
-                Vector3 aboveBotHeadPos = pl.PlayerBones.Pelvis.position + Vector3.up * (pl.HealthController.IsAlive ? 1.1f : 0.3f);
-                Vector3 screenPos = Camera.current.WorldToScreenPoint(aboveBotHeadPos);
-                if (screenPos.z > 0)
-                {
-                    rect.x = screenPos.x * screenScale - rect.width / 2;
-                    rect.y = Screen.height - (screenPos.y + rect.height / 2) * screenScale;
-
-                    GUIStyle labelStyle = middleLabelStyle;
-                    labelStyle.fontSize = 14;
-                    float labelOpacity = 1;
-                    float distanceToCenter = Vector3.Distance(screenPos, new Vector3(Screen.width, Screen.height, 0) / 2);
-
-                    if (distanceToCenter < 100)
-                    {
-                        labelOpacity = distanceToCenter / 100;
-                    }
-
-                    if (ownPlayer.HandsController.IsAiming)
-                    {
-                        labelOpacity *= 0.5f;
-                    }
-
-                    if (pl.HealthController.IsAlive)
-                    {
-                        var maxHealth = pl.HealthController.GetBodyPartHealth(EBodyPart.Common).Maximum;
-                        var currentHealth = pl.HealthController.GetBodyPartHealth(EBodyPart.Common).Current / maxHealth;
-                        labelStyle.normal.textColor = new Color(2.0f * (1 - currentHealth), 2.0f * currentHealth, 0, labelOpacity);
-                    }
-                    else
-                    {
-                        labelStyle.normal.textColor = new Color(255, 0, 0, labelOpacity);
-                    }
-
-                    var distanceFromCamera = Math.Round(Vector3.Distance(Camera.current.gameObject.transform.position, pl.Position));
-                    GUI.Label(rect, $"{pl.Profile.Nickname} {distanceFromCamera}m", labelStyle);
-                }
-            }
-        }
-
-        private void OnGUI_DrawPlayerEnemyTags(Rect rect)
-        {
-            if (SITConfig == null)
-            {
-                Logger.LogError("SITConfig is null?");
-                return;
-            }
-
-            if (!SITConfig.showPlayerNameTagsForEnemies)
-            {
-                return;
-            }
-
-            if (FPSCamera.Instance == null)
-                return;
-
-            if (Players == null)
-                return;
-
-            if (PlayerUsers == null)
-                return;
-
-            if (Camera.current == null)
-                return;
-
-            if (!Singleton<GameWorld>.Instantiated)
-                return;
-
-
-            if (FPSCamera.Instance.SSAA != null && FPSCamera.Instance.SSAA.isActiveAndEnabled)
-                screenScale = FPSCamera.Instance.SSAA.GetOutputWidth() / (float)FPSCamera.Instance.SSAA.GetInputWidth();
-
-            var ownPlayer = Singleton<GameWorld>.Instance.MainPlayer;
-            if (ownPlayer == null)
-                return;
-
-            foreach (var pl in PlayerBots)
-            {
-                if (pl == null)
-                    continue;
-
-                if (pl.HealthController == null)
-                    continue;
-
-                if (!pl.HealthController.IsAlive)
-                    continue;
-
-                Vector3 aboveBotHeadPos = pl.Position + Vector3.up * (pl.HealthController.IsAlive ? 1.5f : 0.5f);
-                Vector3 screenPos = Camera.current.WorldToScreenPoint(aboveBotHeadPos);
-                if (screenPos.z > 0)
-                {
-                    rect.x = screenPos.x * screenScale - rect.width / 2;
-                    rect.y = Screen.height - screenPos.y * screenScale - 15;
-
-                    var distanceFromCamera = Math.Round(Vector3.Distance(Camera.current.gameObject.transform.position, pl.Position));
-                    GUI.Label(rect, $"{pl.Profile.Nickname} {distanceFromCamera}m", middleLabelStyle);
-                    rect.y += 15;
-                    GUI.Label(rect, $"X", middleLabelStyle);
-                }
-            }
-        }
-
-        private void OnGUI_DrawPlayerList(Rect rect)
-        {
-            if (!PluginConfigSettings.Instance.CoopSettings.SETTING_DEBUGShowPlayerList)
-                return;
-
-            rect.y += 15;
-
-            if (PlayersToSpawn.Any(p => p.Value != ESpawnState.Spawned))
-            {
-                GUI.Label(rect, $"Spawning Players:");
-                rect.y += 15;
-                foreach (var p in PlayersToSpawn.Where(p => p.Value != ESpawnState.Spawned))
-                {
-                    GUI.Label(rect, $"{p.Key}:{p.Value}");
-                    rect.y += 15;
-                }
-            }
-
-            if (Singleton<GameWorld>.Instance != null)
-            {
-                var players = Singleton<GameWorld>.Instance.RegisteredPlayers.ToList();
-                players.AddRange(Players.Values);
-                players = players.Distinct(x => x.ProfileId).ToList();
-
-                rect.y += 15;
-                GUI.Label(rect, $"Players [{players.Count}]:");
-                rect.y += 15;
-                foreach (var p in players)
-                {
-                    GUI.Label(rect, $"{p.Profile.Nickname}:{(p.IsAI ? "AI" : "Player")}:{(p.HealthController.IsAlive ? "Alive" : "Dead")}");
-                    rect.y += 15;
-                }
-
-                players.Clear();
-                players = null;
-            }
-        }
     }
 
     public enum ESpawnState

--- a/Source/Coop/Components/CoopGameComponents/SITGameGUIComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameGUIComponent.cs
@@ -41,7 +41,6 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
         int GuiX = 10;
         int GuiWidth = 400;
-        public int ServerPing => CoopGameComponent.ServerPing;
 
         private PaulovTMPManager TMPManager { get; } = new PaulovTMPManager();
         private GameObject _endGameMessageGO;
@@ -147,37 +146,20 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
             var row = () => rect.y += GUI.skin.label.fontSize + 1;
 
-            if (Singleton<ISITGame>.Instance.GameClient is GameClientUDP udp)
-            {
-                rect.x += 65;
+            var gameclient = Singleton<ISITGame>.Instance.GameClient;
 
-                GUI.skin.label.fontSize = 10;
-                GUI.skin.label.alignment = TextAnchor.UpperLeft;
-                GUI.contentColor = Color.white;
+            rect.x += 65;
 
-                var text = new GUIContent($"{(SITMatchmaking.IsClient ? "client" : "host")} ping:{udp.Ping} up:{udp.UploadSpeedKbps} down:{udp.DownloadSpeedKbps} loss:{udp.PacketLoss}% {(AkiBackendCommunication.Instance.HighPingMode ? "hpm" : "")}");
-                // var newX = GUI.skin.label.CalcSize(text);
-                GUI.Label(rect, text);
-                GUI.contentColor = Color.white;
-                row();
+            GUI.skin.label.fontSize = 10;
+            GUI.skin.label.alignment = TextAnchor.UpperLeft;
+            GUI.contentColor = Color.white;
+            var text = new GUIContent($"{(SITMatchmaking.IsClient ? "client" : "host")} ping:{gameclient.Ping} up:{gameclient.UploadSpeedKbps:0.00} down:{gameclient.DownloadSpeedKbps:0.00} loss:{gameclient.PacketLoss:0}% {(AkiBackendCommunication.Instance.HighPingMode ? "hpm" : "")}");
+            // var newX = GUI.skin.label.CalcSize(text);
+            GUI.Label(rect, text);
+            GUI.contentColor = Color.white;
 
-                rect.x -= 65;
-            } else
-            {
-                GUI.Label(rect, $"{StayInTarkovPlugin.LanguageDictionary["SIT_COOP"]}: " + (SITMatchmaking.IsClient ? StayInTarkovPlugin.LanguageDictionary["CLIENT"] : StayInTarkovPlugin.LanguageDictionary["SERVER-PLAY"]));
-                row();
-                GUI.contentColor = ServerPing >= AkiBackendCommunication.PING_LIMIT_HIGH ? Color.red : ServerPing >= AkiBackendCommunication.PING_LIMIT_MID ? Color.yellow : Color.green;
-                GUI.Label(rect, $"{StayInTarkovPlugin.LanguageDictionary["AVG_PING"]}:{(ServerPing)}");
-                GUI.contentColor = Color.white;
-                row();
-                if (AkiBackendCommunication.Instance.HighPingMode)
-                {
-                    GUI.contentColor = Color.yellow;
-                    GUI.Label(rect, (string)StayInTarkovPlugin.LanguageDictionary["HIGH_PING_MODE"]);
-                    GUI.contentColor = Color.white;
-                    row();
-                }
-            }
+            row();
+            rect.x -= 65;
 
             GUI.skin.label.fontSize = prevFontSz;
             GUI.skin.label.alignment = prevAlign;

--- a/Source/Coop/NetworkPacket/BasePacket.cs
+++ b/Source/Coop/NetworkPacket/BasePacket.cs
@@ -427,8 +427,6 @@ namespace StayInTarkov.Coop.NetworkPacket
 
         }
 
-
-
         public Dictionary<string, object> ToDictionary(byte[] data)
         {
             Deserialize(data);

--- a/Source/Coop/NetworkPacket/Player/PlayerRotatePacket.cs
+++ b/Source/Coop/NetworkPacket/Player/PlayerRotatePacket.cs
@@ -51,9 +51,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player
 
         protected override void Process(CoopPlayerClient client)
         {
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-
             client.Rotation = new UnityEngine.Vector2(RotationX, RotationY);
         }
     }

--- a/Source/Coop/NetworkPacket/Player/PlayerStatesPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/PlayerStatesPacket.cs
@@ -50,10 +50,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player
         {
             //StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(PlayerStatesPacket)}:{nameof(Process)}:{this.SITToJson()}");
 
-
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-
             for (var i = 0; i < PlayerStates.Length; i++)
                 PlayerStates[i].Process();
         }

--- a/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedGrenadePacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedGrenadePacket.cs
@@ -51,9 +51,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Proceed
 
         protected override void Process(CoopPlayerClient client)
         {
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-
             if (ItemFinder.TryFindItem(ItemId, out var item) && item is GrenadeClass grenade)
             {
                 client.Proceed(grenade, (Comfort.Common.Result<IThrowableCallback> x) => { }, Scheduled);

--- a/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedKnifePacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedKnifePacket.cs
@@ -55,9 +55,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Proceed
 
         protected override void Process(CoopPlayerClient client)
         {
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-
             if (ItemFinder.TryFindItem(ItemId, out var item))
             {
                 if(QuickKnife)

--- a/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedWeaponPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Proceed/PlayerProceedWeaponPacket.cs
@@ -50,9 +50,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Proceed
 
         protected override void Process(CoopPlayerClient client)
         {
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
-
             if (ItemFinder.TryFindItem(ItemId, out var item))
             {
                 client.Proceed((Weapon)item, (x) => { }, Scheduled);

--- a/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadeHighThrowPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadeHighThrowPacket.cs
@@ -53,7 +53,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons.Grenade
         {
             if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
             {
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
                 if (client.HandsController is EFT.Player.GrenadeController gc)
                 {
                     client.Rotation = new UnityEngine.Vector2(RotationX, RotationY);

--- a/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadeLowThrowPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadeLowThrowPacket.cs
@@ -53,7 +53,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons.Grenade
         {
             if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
             {
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
                 if (client.HandsController is EFT.Player.GrenadeController gc)
                 {
                     client.Rotation = new UnityEngine.Vector2(RotationX, RotationY);

--- a/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadePullRingForHighThrowPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadePullRingForHighThrowPacket.cs
@@ -43,7 +43,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons.Grenade
         {
             if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
             {
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
                 if (client.HandsController is EFT.Player.GrenadeController gc)
                 {
                     gc.PullRingForHighThrow();

--- a/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadePullRingForLowThrowPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/Grenade/GrenadePullRingForLowThrowPacket.cs
@@ -43,7 +43,6 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Weapons.Grenade
         {
             if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
             {
-                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
                 if (client.HandsController is EFT.Player.GrenadeController gc)
                 {
                     gc.PullRingForLowThrow();

--- a/Source/Coop/NetworkPacket/Player/Weapons/TriggerPressedPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Weapons/TriggerPressedPacket.cs
@@ -57,7 +57,6 @@
 //        {
 //            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
 //            {
-//                coopGameComponent.UpdatePing(GetTimeSinceSent().Milliseconds);
 //                if (client.HandsController is EFT.Player.FirearmController fc)
 //                {
 //                    fc.SetTriggerPressed(Pressed);

--- a/Source/Coop/Players/CoopPlayerClient.cs
+++ b/Source/Coop/Players/CoopPlayerClient.cs
@@ -102,11 +102,6 @@ namespace StayInTarkov.Coop.Players
         {
             NewState = playerStatePacket;
             //BepInLogger.LogInfo($"{nameof(ReceivePlayerStatePacket)}:Packet took {DateTime.Now - new DateTime(long.Parse(NewState.TimeSerializedBetter))}.");
-            if (SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-            {
-                var ms = (DateTime.Now - new DateTime(long.Parse(NewState.TimeSerializedBetter))).Milliseconds;
-                coopGameComponent.ServerPingSmooth.Enqueue(ms);
-            }
 
             //BepInLogger.LogInfo(NewState.ToJson());
 

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -255,7 +255,6 @@ namespace StayInTarkov.Coop.SITGameModes
 
             if (SITMatchmaking.IsServer)
             {
-                //StartCoroutine(HostPinger());
                 StartCoroutine(GameTimerSync());
                 StartCoroutine(TimeAndWeatherSync());
                 StartCoroutine(ArmoredTrainTimeSync());
@@ -281,7 +280,6 @@ namespace StayInTarkov.Coop.SITGameModes
                 AkiBackendCommunication.Instance.PostDownWebSocketImmediately("CLIENT_LOADING_KEEP_ALIVE");
 
                 yield return waitSeconds;
-
             }
         }
 
@@ -303,24 +301,6 @@ namespace StayInTarkov.Coop.SITGameModes
                 }
                 yield return waitSeconds;
 
-            }
-        }
-
-        private IEnumerator HostPinger()
-        {
-            var waitSeconds = new WaitForSeconds(1f);
-
-            while (true)
-            {
-                yield return waitSeconds;
-
-                if (!SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
-                    yield break;
-
-                Dictionary<string, string> hostPingerPacket = new();
-                hostPingerPacket.Add("HostPing", DateTime.UtcNow.Ticks.ToString());
-                hostPingerPacket.Add("serverId", coopGameComponent.ServerId);
-                Networking.GameClient.SendData(hostPingerPacket.ToJson());
             }
         }
 
@@ -1524,6 +1504,7 @@ namespace StayInTarkov.Coop.SITGameModes
                 exfiltrationPoint.OnCancelExtraction -= ExfiltrationPoint_OnCancelExtraction;
                 exfiltrationPoint.OnStatusChanged -= ExfiltrationPoint_OnStatusChanged;
             }
+
             base.Dispose();
         }
 

--- a/Source/Networking/GameClientTCPRelay.cs
+++ b/Source/Networking/GameClientTCPRelay.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -12,7 +13,17 @@ namespace StayInTarkov.Networking
 {
     public class GameClientTCPRelay : MonoBehaviour, IGameClient
     {
-        public BlockingCollection<byte[]> PooledBytesToPost { get; } = new BlockingCollection<byte[]>();
+        public BlockingCollection<byte[]> PooledBytesToPost { get; } = [];
+        public float DownloadSpeedKbps { get; private set; } = 0;
+        public float UploadSpeedKbps { get; private set; } = 0;
+        public uint PacketLoss { get; private set; } = 0;
+        public ushort Ping
+        {
+            get
+            {
+                return AkiBackendCommunication.Instance.Ping;
+            }
+        }
 
         void Awake()
         {
@@ -26,7 +37,6 @@ namespace StayInTarkov.Networking
 
         void Update()
         {
-
             if (PooledBytesToPost != null)
             {
                 while (PooledBytesToPost.Any())
@@ -50,6 +60,12 @@ namespace StayInTarkov.Networking
         public void SendData<T>(ref T packet) where T : BasePacket
         {
             SendData(packet.Serialize());
+        }
+
+        void IGameClient.ResetStats()
+        {
+            DownloadSpeedKbps = Interlocked.Exchange(ref AkiBackendCommunication.Instance.BytesReceived, 0) / 1024f;
+            UploadSpeedKbps = Interlocked.Exchange(ref AkiBackendCommunication.Instance.BytesSent, 0) / 1024f;
         }
     }
 }

--- a/Source/Networking/GameClientUDP.cs
+++ b/Source/Networking/GameClientUDP.cs
@@ -46,11 +46,11 @@ namespace StayInTarkov.Networking
         private NetDataWriter _dataWriter = new();
         private SITGameComponent CoopGameComponent { get; set; }
         public NetPacketProcessor _packetProcessor = new();
-        public int Ping = 0;
         public int ConnectedClients = 0;
-        public float DownloadSpeedKbps;
-        public float UploadSpeedKbps;
-        public float PacketLoss;
+        public ushort Ping { get; private set; } = 0;
+        public float DownloadSpeedKbps { get; private set; } = 0;
+        public float UploadSpeedKbps { get; private set; } = 0;
+        public uint PacketLoss { get; private set; } = 0;
         private ManualLogSource Logger { get; set; }
 
         void Awake()
@@ -164,9 +164,9 @@ namespace StayInTarkov.Networking
 
         public void ResetStats()
         {
-            DownloadSpeedKbps = _netClient.Statistics.BytesReceived / 1024;
-            UploadSpeedKbps = _netClient.Statistics.BytesSent / 1024;
-            PacketLoss = _netClient.Statistics.PacketLoss == 0 ? 0 : 100f * (_netClient.Statistics.PacketsSent / _netClient.Statistics.PacketLoss);
+            DownloadSpeedKbps = _netClient.Statistics.BytesReceived / 1024f;
+            UploadSpeedKbps = _netClient.Statistics.BytesSent / 1024f;
+            PacketLoss = (uint)(_netClient.Statistics.PacketLoss == 0 ? 0 : (100 * _netClient.Statistics.PacketLoss / _netClient.Statistics.PacketsSent));
             _netClient.Statistics.Reset();
         }
 
@@ -222,7 +222,7 @@ namespace StayInTarkov.Networking
 
         public void OnNetworkLatencyUpdate(NetPeer peer, int latency)
         {
-            Ping = latency;
+            Ping = (ushort)latency;
         }
 
         public void OnConnectionRequest(LiteNetLib.ConnectionRequest request)

--- a/Source/Networking/IGameClient.cs
+++ b/Source/Networking/IGameClient.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,6 +10,19 @@ namespace StayInTarkov.Networking
 {
     public interface IGameClient
     {
+        /// <summary>
+        /// Latency to server in milliseconds (RTT / 2)
+        /// </summary>
+        public ushort Ping { get; }
+        public float UploadSpeedKbps { get; }
+        public float DownloadSpeedKbps { get; }
+        public uint PacketLoss { get; }
+
+        /// <summary>
+        /// Reset stats and compute download/upload speed and packet loss
+        /// </summary>
+        public void ResetStats();
+
         /// <summary>
         /// Will send bytes to the Server
         /// </summary>


### PR DESCRIPTION
- in preparation for network optimizations, display ping, down/up speeds and packet loss for all client types
- enable new netstat gui for tcp relay (was on for udp already)
- removed a bunch of old code around ping
- fixed NRE that would break the periodic websocket pinger