### PR TITLE
clean up debug logs around packet processing

### DIFF
--- a/Source/Coop/Components/ActionPacketHandlerComponent.cs
+++ b/Source/Coop/Components/ActionPacketHandlerComponent.cs
@@ -106,42 +106,59 @@ namespace StayInTarkov.Coop.Components
 
             if (ActionSITPackets.Count > 0)
             {
+#if DEBUGPACKETS
                 Stopwatch stopwatchActionPackets = Stopwatch.StartNew();
+#endif
                 while (ActionSITPackets.TryTake(out var packet))
                 {
-                    
+#if DEBUGPACKETS
                     Stopwatch stopwatchActionPacket = Stopwatch.StartNew();
+#endif
                     packet.Process();
 
+#if DEBUGPACKETS
                     if (stopwatchActionPacket.ElapsedMilliseconds > 1)
                         Logger.LogDebug($"ActionSITPacket {packet.Method} took {stopwatchActionPacket.ElapsedMilliseconds}ms to process!");
+#endif
                 }
+#if DEBUGPACKETS
                 if (stopwatchActionPackets.ElapsedMilliseconds > 1)
                     Logger.LogDebug($"ActionSITPackets took {stopwatchActionPackets.ElapsedMilliseconds}ms to process!");
+#endif
             }
 
             if (ActionPackets.Count > 0)
             {
+#if DEBUGPACKETS
                 Stopwatch stopwatchActionPackets = Stopwatch.StartNew();
+#endif
                 while (ActionPackets.TryTake(out var result))
                 {
+#if DEBUGPACKETS
                     Stopwatch stopwatchActionPacket = Stopwatch.StartNew();
+#endif
                     if (!ProcessLastActionDataPacket(result))
                     {
                         //ActionPackets.Add(result);
                         continue;
                     }
 
+#if DEBUGPACKETS
                     if (stopwatchActionPacket.ElapsedMilliseconds > 1)
                         Logger.LogDebug($"ActionPacket {result["m"]} took {stopwatchActionPacket.ElapsedMilliseconds}ms to process!");
+#endif
                 }
+#if DEBUGPACKETS
                 if (stopwatchActionPackets.ElapsedMilliseconds > 1)
                     Logger.LogDebug($"ActionPackets took {stopwatchActionPackets.ElapsedMilliseconds}ms to process!");
+#endif
             }
 
             if (ActionPacketsMovement != null && ActionPacketsMovement.Count > 0)
             {
+#if DEBUGPACKETS
                 Stopwatch stopwatchActionPacketsMovement = Stopwatch.StartNew();
+#endif
                 while (ActionPacketsMovement.TryTake(out var result))
                 {
                     if (!ProcessLastActionDataPacket(result))
@@ -150,10 +167,12 @@ namespace StayInTarkov.Coop.Components
                         continue;
                     }
                 }
+#if DEBUGPACKETS
                 if (stopwatchActionPacketsMovement.ElapsedMilliseconds > 1)
                 {
                     Logger.LogDebug($"ActionPacketsMovement took {stopwatchActionPacketsMovement.ElapsedMilliseconds}ms to process!");
                 }
+#endif
             }
 
 

--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -231,17 +231,9 @@ namespace StayInTarkov.Networking
             if (e == null)
                 return;
 
-            if(DEBUGPACKETS)
-            {
-                Logger.LogDebug(e.Data);
-            }
-
             SITGameServerClientDataProcessing.ProcessPacketBytes(e.RawData, e.Data);
             GC.RemoveMemoryPressure(e.RawData.Length);
-
         }
-
-        
 
         public static AkiBackendCommunication GetRequestInstance(bool createInstance = false, ManualLogSource logger = null)
         {
@@ -252,8 +244,6 @@ namespace StayInTarkov.Networking
 
             return Instance;
         }
-
-        public static bool DEBUGPACKETS { get; } = false;
 
         public bool HighPingMode { get; set; }
 

--- a/Source/Networking/SITGameServerClientDataProcessing.cs
+++ b/Source/Networking/SITGameServerClientDataProcessing.cs
@@ -19,8 +19,6 @@ namespace StayInTarkov.Networking
 {
     public static class SITGameServerClientDataProcessing
     {
-        public static bool DEBUGPACKETS = false;
-
         public const string PACKET_TAG_METHOD = "m";
         public const string PACKET_TAG_SERVERID = "serverId";
         public const string PACKET_TAG_DATA = "data";
@@ -68,17 +66,7 @@ namespace StayInTarkov.Networking
                 // Is a RAW SIT Serialized packet
                 else
                 {
-
-                    //Logger.LogDebug(Encoding.UTF8.GetString(data));
-                    //BasePlayerPacket basePlayerPacket = new BasePlayerPacket();
-                    //packet = basePlayerPacket.ToDictionary(data);
                     ProcessSITPacket(data, ref packet, out sitPacket);
-
-                }
-
-                if (DEBUGPACKETS)
-                {
-                    Logger.LogInfo("GOT :" + sData);
                 }
 
                 var coopGameComponent = SITGameComponent.GetCoopGameComponent();
@@ -93,11 +81,6 @@ namespace StayInTarkov.Networking
                 {
                     //Logger.LogError($"{nameof(ProcessPacketBytes)}. Packet is Null");
                     return;
-                }
-
-                if (DEBUGPACKETS)
-                {
-                    Logger.LogInfo("GOT :" + packet.SITToJson());
                 }
 
                 if (packet.ContainsKey("dataList"))
@@ -147,13 +130,10 @@ namespace StayInTarkov.Networking
                     return;
                 }
 
-
-
                 // -------------------------------------------------------
                 // Add to the Coop Game Component Action Packets
                 if (coopGameComponent == null || coopGameComponent.ActionPackets == null || coopGameComponent.ActionPacketHandler == null)
                     return;
-
 
                 //if (packet.ContainsKey(PACKET_TAG_METHOD)
                 //    && packet[PACKET_TAG_METHOD].ToString() == "Move")
@@ -237,12 +217,6 @@ namespace StayInTarkov.Networking
                     bpp = null;
                 }
                 catch { }
-            }
-
-            if (DEBUGPACKETS)
-            {
-                Logger.LogInfo(" ==================SIT Packet============= ");
-                Logger.LogInfo(dictObject.ToJson());
             }
 
             packet = DeserializeIntoPacket(data, packet, bp);


### PR DESCRIPTION
- limit annoying logs by default
- use `#define DEBUGPACKETS` when needed in dev
- use wireshark to inspect packet contents or add ad-hoc logs when needed in dev