### PR TITLE
SIT Garbage Collection 2.0

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -40,21 +40,37 @@ namespace StayInTarkov.Configuration
 
         public class SITAdvancedSettings
         {
+            public const string Advanced = "Advanced";
             public ConfigFile Config { get; }
             public ManualLogSource Logger { get; }
+
+            public bool SETTING_EnableSITGC
+            {
+                get
+                {
+                    return StayInTarkovPlugin.Instance.Config.Bind
+                       (Advanced, "EnableSITGC", false, new ConfigDescription("Enable SIT's own Garbage Collector")).Value;
+                }
+            }
+
+            public uint SETTING_SITGCMemoryThreshold
+            {
+                get
+                {
+                    return StayInTarkovPlugin.Instance.Config.Bind
+                       (Advanced, "SITGCMemoryThreshold", 90u, new ConfigDescription("SIT's Garbage Collector. System Memory % before SIT forces a Garbage Collection.")).Value;
+                }
+            }
+
 
             public SITAdvancedSettings(ManualLogSource logger, ConfigFile config)
             {
                 Logger = logger;
                 Config = config;
-                GetSettings();
+                _ = SETTING_EnableSITGC;
+                _ = SETTING_SITGCMemoryThreshold;
             }
 
-
-            public void GetSettings()
-            {
-
-            }
         }
 
         public class CoopConfigSettings

--- a/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
+++ b/Source/Coop/Components/CoopGameComponents/SITGameComponent.cs
@@ -331,12 +331,8 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
             //    CoopSITGame.SendPlayerDataToServer((LocalPlayer)Singleton<GameWorld>.Instance.RegisteredPlayers.First(x => x.IsYourPlayer));
             //}
 
-            // Start the SIT Garbage Collector
-            BSGMemoryGC.RunHeapPreAllocation();
-            BSGMemoryGC.Collect(force: true);
-            BSGMemoryGC.EmptyWorkingSet();
-            BSGMemoryGC.GCEnabled = true;
-            Resources.UnloadUnusedAssets();
+            GarbageCollect();
+            StartCoroutine(GarbageCollectSIT());
 
             StartCoroutine(SendPlayerStatePacket());
 
@@ -360,6 +356,59 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
             // Get a List of Interactive Objects (this is a slow method), so run once here to maintain a reference
             ListOfInteractiveObjects = FindObjectsOfType<WorldInteractiveObject>();
+        }
+
+        private void GarbageCollect()
+        {
+            // Start the SIT Garbage Collector
+            Logger.LogDebug($"{nameof(GarbageCollect)}");   
+            BSGMemoryGC.RunHeapPreAllocation();
+            BSGMemoryGC.Collect(force: true);
+            BSGMemoryGC.EmptyWorkingSet();
+            BSGMemoryGC.GCEnabled = true;
+            //Resources.UnloadUnusedAssets();
+        }
+
+        /// <summary>
+        /// Runs the Garbage Collection every 5 minutes
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator GarbageCollectSIT()
+        {
+            while(true)
+            {
+                if (PluginConfigSettings.Instance.AdvancedSettings.SETTING_EnableSITGC)
+                {
+                    var nearestEnemyDist = float.MaxValue;
+                    foreach(var p in Players)
+                    {
+                        if (p.Key == Singleton<GameWorld>.Instance.MainPlayer.ProfileId)
+                            continue;
+
+                        var dist = Vector3.Distance(p.Value.Transform.position, Singleton<GameWorld>.Instance.MainPlayer.Transform.position);
+                        if(dist < nearestEnemyDist)
+                            nearestEnemyDist = dist;
+                    }
+
+                    if (nearestEnemyDist > 10)
+                    {
+                        var mem = MemoryInfo.GetCurrentStatus();
+                        if (mem == null)
+                        {
+                            yield return new WaitForSeconds(1);
+                            continue;
+                        }
+
+                        var memPercentInUse = mem.dwMemoryLoad;
+                        Logger.LogDebug($"Total memory used: {mem.dwMemoryLoad}%");
+                        if (memPercentInUse > PluginConfigSettings.Instance.AdvancedSettings.SETTING_SITGCMemoryThreshold)
+                            GarbageCollect();
+
+                    }
+                }
+
+                yield return new WaitForSeconds(60);
+            }
         }
 
         /// <summary>
@@ -454,7 +503,7 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                                 player.Profile.EftStats.SessionCounters.AddDouble(0.01,
                                 [
                                     CounterTag.FenceStanding,
-                                EFenceStandingSource.ExitStanding
+                                    EFenceStandingSource.ExitStanding
                                 ]);
                             }
                             AkiBackendCommunicationCoop.PostLocalPlayerData(player
@@ -504,10 +553,29 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                     {
                         coopGame.GameClient.ResetStats();
                     }
+
+                    ProcessOtherModsSpawnedPlayers();
+
                 }
                 catch (Exception ex)
                 {
                     Logger.LogError($"{nameof(EverySecondCoroutine)}: caught exception:\n{ex}");
+                }
+            }
+        }
+
+        private void ProcessOtherModsSpawnedPlayers()
+        {
+            // If another mod has spawned people, attempt to handle it.
+            foreach (var p in Singleton<GameWorld>.Instance.AllAlivePlayersList)
+            {
+                if (!Players.ContainsKey(p.ProfileId))
+                {
+                    // As these created players are unlikely to be CoopPlayer, throw an error!
+                    if((p as CoopPlayer) == null)
+                    {
+                        Logger.LogError($"Player of Id:{p.ProfileId} is not found in the SIT {nameof(Players)} list?!");
+                    }
                 }
             }
         }
@@ -518,19 +586,6 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
         {
             StayInTarkovHelperConstants.Logger.LogDebug($"CoopGameComponent:OnDestroy");
 
-            //if (Players != null)
-            //{
-            //    foreach (var pl in Players)
-            //    {
-            //        if (pl.Value == null)
-            //            continue;
-
-            //        if (pl.Value.TryGetComponent<PlayerReplicatedComponent>(out var prc))
-            //        {
-            //            DestroyImmediate(prc);
-            //        }
-            //    }
-            //}
             Players.Clear();
             PlayersToSpawnProfiles.Clear();
             PlayersToSpawnPositions.Clear();
@@ -1101,6 +1156,14 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                 // If not showing drones. Check whether the "Player" has been registered, if they have, then ignore the drone
                 if (!PluginConfigSettings.Instance.CoopSettings.SETTING_DEBUGSpawnDronesOnServer)
                 {
+                    if (Singleton<GameWorld>.Instance.AllAlivePlayersList.Any(x => x.ProfileId == p.Key))
+                    {
+                        if (PlayersToSpawn.ContainsKey(p.Key))
+                            PlayersToSpawn[p.Key] = ESpawnState.Ignore;
+
+                        continue;
+                    }
+
                     if (Singleton<GameWorld>.Instance.RegisteredPlayers.Any(x => x.ProfileId == p.Key))
                     {
                         if (PlayersToSpawn.ContainsKey(p.Key))
@@ -1225,7 +1288,6 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
                     if (Singleton<GameWorld>.Instance.RegisteredPlayers.Any(x => x.ProfileId == profile.ProfileId))
                         return;
 
-
                     if (Singleton<GameWorld>.Instance.AllAlivePlayersList.Any(x => x.ProfileId == profile.ProfileId))
                         return;
 
@@ -1301,14 +1363,12 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
                 // ------------------------------------------------------------------
                 // Create Local Player drone
-                LocalPlayer otherPlayer = CreateLocalPlayer(profile, PlayersToSpawnPositions[profile.Id], playerId);
+                var otherPlayer = SpawnCharacter(profile, PlayersToSpawnPositions[profile.Id], playerId);
                 if (otherPlayer == null)
                 {
                     PlayersToSpawn[profile.ProfileId] = ESpawnState.Spawning;
                     return;
                 }
-                // TODO: I would like to use the following, but it causes the drones to spawn without a weapon.
-                //CreateLocalPlayerAsync(profile, position, playerId);
 
                 if (isDead)
                 {
@@ -1323,9 +1383,9 @@ namespace StayInTarkov.Coop.Components.CoopGameComponents
 
         }
 
-        private LocalPlayer CreateLocalPlayer(Profile profile, Vector3 position, int playerId)
+        private LocalPlayer SpawnCharacter(Profile profile, Vector3 position, int playerId)
         {
-            Logger.LogDebug($"{nameof(CreateLocalPlayer)}:{nameof(position)}:{position}");
+            Logger.LogDebug($"{nameof(SpawnCharacter)}:{nameof(position)}:{position}");
 
             // If this is an actual PLAYER player that we're creating a drone for, when we set
             // aiControl to true then they'll automatically run voice lines (eg when throwing

--- a/Source/Memory/GCHelpers.cs
+++ b/Source/Memory/GCHelpers.cs
@@ -130,4 +130,96 @@ namespace StayInTarkov.Memory
             PreviousTime = Time.time;
         }
     }
+
+    /// <summary>
+    /// Taken from https://raw.githubusercontent.com/BepInEx/BepInEx.Utility/master/BepInEx.ResourceUnloadOptimizations/MemoryInfo.cs
+    /// Credits to BepInEx
+    /// Provides information about system memory status
+    /// </summary>
+    internal static class MemoryInfo
+        {
+            /// <summary>
+            /// Can return null if the call fails for whatever reason
+            /// </summary>
+            public static MEMORYSTATUSEX GetCurrentStatus()
+            {
+                try
+                {
+                    var msex = new MEMORYSTATUSEX();
+                    if (GlobalMemoryStatusEx(msex))
+                        return msex;
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    return null;
+                }
+            }
+
+            /// <summary>
+            /// contains information about the current state of both physical and virtual memory, including extended memory
+            /// </summary>
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+            public class MEMORYSTATUSEX
+            {
+                /// <summary>
+                /// Size of the structure, in bytes. You must set this member before calling GlobalMemoryStatusEx.
+                /// </summary>
+                public uint dwLength;
+
+                /// <summary>
+                /// Number between 0 and 100 that specifies the approximate percentage of physical memory that is in use (0 indicates no memory use and 100 indicates full memory use).
+                /// </summary>
+                public uint dwMemoryLoad;
+
+                /// <summary>
+                /// Total size of physical memory, in bytes.
+                /// </summary>
+                public ulong ullTotalPhys;
+
+                /// <summary>
+                /// Size of physical memory available, in bytes.
+                /// </summary>
+                public ulong ullAvailPhys;
+
+                /// <summary>
+                /// Size of the committed memory limit, in bytes. This is physical memory plus the size of the page file, minus a small overhead.
+                /// </summary>
+                public ulong ullTotalPageFile;
+
+                /// <summary>
+                /// Size of available memory to commit, in bytes. The limit is ullTotalPageFile.
+                /// </summary>
+                public ulong ullAvailPageFile;
+
+                /// <summary>
+                /// Total size of the user mode portion of the virtual address space of the calling process, in bytes.
+                /// </summary>
+                public ulong ullTotalVirtual;
+
+                /// <summary>
+                /// Size of unreserved and uncommitted memory in the user mode portion of the virtual address space of the calling process, in bytes.
+                /// </summary>
+                public ulong ullAvailVirtual;
+
+                /// <summary>
+                /// Size of unreserved and uncommitted memory in the extended portion of the virtual address space of the calling process, in bytes.
+                /// </summary>
+                public ulong ullAvailExtendedVirtual;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="T:MEMORYSTATUSEX"/> class.
+                /// </summary>
+                public MEMORYSTATUSEX()
+                {
+                    dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
+                }
+            }
+
+            [return: MarshalAs(UnmanagedType.Bool)]
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            private static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
+        }
+
 }


### PR DESCRIPTION
- Add back SIT GC that is off by default
- Has much better memory cosumption detection than previous attempts
- Only fires Garbage Collection when reaching a system threshold
- Only fires Garbage Collection when no enemies are around
- Default settings only execute the GC when it enabled & exceeds the 90% of system RAM