### PR TITLE
Fix a small singleplayer bug

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -839,6 +839,8 @@ namespace StayInTarkov.Coop.Components
             RaidSettings.WavesSettings.BotDifficulty = EBotDifficulty.AsOnline;
             RaidSettings.WavesSettings.IsBosses = true;
 
+            SITMatchmaking.HostExpectedNumberOfPlayers = 1;
+
             SITMatchmaking.CreateMatch(
                 SITMatchmaking.Profile.ProfileId
                 , RaidSettings


### PR DESCRIPTION
Once create or join a host raid that players > 1, after this raid, try playing singleplayer will need to wait for special number of players in last raid to start singleplayer game.

This fix will set HostExpectedNumberOfPlayers to 1 when HostSoloRaidAndJoin function run.