### PR TITLE
[debug] add autoraid

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -795,12 +795,12 @@ namespace StayInTarkov.Coop.Components
             DestroyThis();
         }
 
-        private void HostSoloRaidAndJoin()
+        public void HostSoloRaidAndJoin(ESITProtocol protocol = ESITProtocol.RelayTcp, EBotAmount botAmount = EBotAmount.AsOnline)
         {
             FixesHideoutMusclePain();
 
-            RaidSettings.BotSettings.BotAmount = EBotAmount.AsOnline;
-            RaidSettings.WavesSettings.BotAmount = EBotAmount.AsOnline;
+            RaidSettings.BotSettings.BotAmount = botAmount;
+            RaidSettings.WavesSettings.BotAmount = botAmount;
             RaidSettings.WavesSettings.BotDifficulty = EBotDifficulty.AsOnline;
             RaidSettings.WavesSettings.IsBosses = true;
 
@@ -810,7 +810,7 @@ namespace StayInTarkov.Coop.Components
                 SITMatchmaking.Profile.ProfileId
                 , RaidSettings
                 , ""
-                , ESITProtocol.RelayTcp
+                , protocol
                 , null
                 , PluginConfigSettings.Instance.CoopSettings.UdpServerLocalPort,
                 EMatchmakerType.GroupLeader);

--- a/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptScreenShowPatch.cs
+++ b/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptScreenShowPatch.cs
@@ -29,7 +29,7 @@ namespace StayInTarkov.Coop.Matchmaker
 
         private static DateTime LastClickedTime { get; set; } = DateTime.MinValue;
 
-        private static GameObject MatchmakerObject { get; set; }
+        public static GameObject MatchmakerObject { get; set; }
 
         [PatchPrefix]
         private static void Pre(

--- a/Source/Coop/TarkovApplication_LocalGameCreator_Patch.cs
+++ b/Source/Coop/TarkovApplication_LocalGameCreator_Patch.cs
@@ -161,6 +161,11 @@ namespace StayInTarkov.Coop
                 , TimeSpan.FromSeconds(60 * ____raidSettings.SelectedLocation.EscapeTimeLimit)
             //}
             );
+            var i = 100;
+            while (!localGame.Ready() && i-- > 0)
+            {
+                await Task.Delay(100);
+            }
             Singleton<AbstractGame>.Create(localGame);
             timeHasComeScreenController.ChangeStatus(StayInTarkovPlugin.LanguageDictionary["CREATED_COOP_GAME"].ToString());
 

--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -870,6 +870,7 @@ namespace StayInTarkov.Networking
                 catch (Exception ex)
                 {
 #if DEBUG
+                    StayInTarkovHelperConstants.Logger.LogError($"could not perform request @ {url}");
                     StayInTarkovHelperConstants.Logger.LogError(new System.Diagnostics.StackTrace());
                     StayInTarkovHelperConstants.Logger.LogError(ex);
 #endif

--- a/Source/Networking/GameClientUDP.cs
+++ b/Source/Networking/GameClientUDP.cs
@@ -145,6 +145,13 @@ namespace StayInTarkov.Networking
             }
             else if (SITMatchmaking.IsServer)
             {
+                var serv = GetComponent<GameServerUDP>();
+                while (!serv.NetServer.IsRunning)
+                {
+                    Logger.LogDebug("Waiting for UDP server to start");
+                    await Task.Delay(1000);
+                }
+
                 // Connect locally if we're the server.
                 var endpoint = new IPEndPoint(IPAddress.Loopback, PluginConfigSettings.Instance.CoopSettings.UdpServerLocalPort);
                 var msg = $"Server connecting as client to {endpoint}";
@@ -154,6 +161,7 @@ namespace StayInTarkov.Networking
                 _netClient.Connect(endpoint, "sit.core");
             }
         }
+
         void Update()
         {
             _netClient.PollEvents();
@@ -175,6 +183,8 @@ namespace StayInTarkov.Networking
 
         void OnDestroy()
         {
+            Logger.LogDebug("OnDestroy()");
+
             if (_netClient != null)
                 _netClient.Stop();
 

--- a/Source/Networking/GameServerUDP.cs
+++ b/Source/Networking/GameServerUDP.cs
@@ -128,6 +128,7 @@ namespace StayInTarkov.Networking
 
         void OnDestroy()
         {
+            Logger.LogDebug("OnDestroy()");
             NetDebug.Logger = null;
             
             if (_netServer != null)

--- a/Source/StayInTarkov.csproj
+++ b/Source/StayInTarkov.csproj
@@ -155,5 +155,4 @@
     <Folder Include="Multiplayer\" />
     <Folder Include="Properties\" />
   </ItemGroup>
-  
 </Project>

--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -17,8 +17,6 @@ using StayInTarkov.EssentialPatches;
 using StayInTarkov.EssentialPatches.Web;
 using StayInTarkov.FileChecker;
 using StayInTarkov.Health;
-using StayInTarkov.Networking;
-using StayInTarkov.ThirdParty;
 using StayInTarkov.UI;
 using System;
 using System.Collections;
@@ -29,6 +27,7 @@ using System.Text;
 using System.Threading;
 using BepInEx.Configuration;
 using UnityEngine;
+using StayInTarkov.Tools;
 
 namespace StayInTarkov
 {
@@ -75,7 +74,6 @@ namespace StayInTarkov
 
         public static bool LanguageDictionaryLoaded { get; private set; }
 
-
         internal static string IllegalMessage { get; }
             = LanguageDictionaryLoaded && LanguageDictionary.ContainsKey("ILLEGAL_MESSAGE")
                 ? LanguageDictionary["ILLEGAL_MESSAGE"].ToString()
@@ -95,14 +93,20 @@ namespace StayInTarkov
             ReadInLanguageDictionary();
 
             EnableCorePatches();
-            EnableBundlePatches();
 
+            EnableBundlePatches();
 
             EnableSPPatches();
 
             EnableCoopPatches();
 
             EnableAirdropPatches();
+
+            if (Autoraid.Requested())
+            {
+                Logger.LogInfo($"Running autoraid");
+                gameObject.GetOrAddComponent<Autoraid>();
+            }
 
             Logger.LogInfo($"Stay in Tarkov is loaded!");
         }

--- a/Source/Tools/Autoraid.cs
+++ b/Source/Tools/Autoraid.cs
@@ -1,0 +1,208 @@
+﻿using BepInEx.Logging;
+using Comfort.Common;
+using EFT;
+using EFT.Bots;
+using EFT.UI;
+using EFT.UI.Matchmaker;
+using EFT.UI.Screens;
+using EFT.UI.SessionEnd;
+using JsonType;
+using StayInTarkov.Coop.Components;
+using StayInTarkov.Coop.Matchmaker;
+using StayInTarkov.Coop.SITGameModes;
+using StayInTarkov.Health;
+using StayInTarkov.Networking;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace StayInTarkov.Tools
+{
+    public class Autoraid : MonoBehaviour
+    {
+        public static bool Running = false;
+
+        public void Start()
+        {
+            ScreenManager.Instance.OnScreenChanged += OnScreenChanged;
+        }
+
+        public void OnDestroy()
+        {
+            Running = false;
+        }
+
+        public static bool Requested()
+        {
+            return Environment.GetCommandLineArgs().FirstOrDefault(x => x == "-autoraid") != null;
+        }
+
+        private void OnScreenChanged(EEftScreenType x)
+        {
+            if (x == EEftScreenType.MainMenu)
+            {
+                Running = true;
+                ScreenManager.Instance.OnScreenChanged -= OnScreenChanged;
+
+                IEnumerator autoraid()
+                {
+                    try
+                    {
+                        var i = 3;
+
+                        while (i-- > 0)
+                        {
+                            var screens = (Dictionary<EEftScreenType, UIScreen>)ReflectionHelpers.GetFieldFromType(typeof(ScreenManager), "dictionary_0").GetValue(ScreenManager.Instance);
+
+                            {
+                                yield return new WaitUntil(() => screens.ContainsKey(EEftScreenType.MainMenu) && screens[EEftScreenType.MainMenu].gameObject.activeSelf);
+                                var playButton = new WaitForButton<MenuScreen, DefaultUIButton>(screens[EEftScreenType.MainMenu], "_playButton");
+                                yield return playButton;
+                                playButton.Button.OnClick.Invoke();
+                            }
+
+                            {
+                                var pmcButton = new WaitForButton<MatchMakerSideSelectionScreen, UnityEngine.UI.Button>(screens[EEftScreenType.SelectRaidSide], "_pmcBigButton");
+                                yield return pmcButton;
+                                pmcButton.Button.OnPointerClick(new PointerEventData(EventSystem.current)
+                                {
+                                    button = PointerEventData.InputButton.Left
+                                });
+                                var nextButton = new WaitForButton<MatchMakerSideSelectionScreen, DefaultUIButton>(screens[EEftScreenType.SelectRaidSide], "_nextButton");
+                                yield return nextButton;
+                                nextButton.Button.OnClick.Invoke();
+                            }
+
+                            // remove as much non-determinism as we can
+                            var app = StayInTarkovHelperConstants.GetMainApp();
+                            var botSettings = new BotControllerSettings(isScavWars: false, EBotAmount.Horde, EBossType.AsOnline);
+                            var locationSettings = app.Session.LocationSettings;
+                            var location = locationSettings.locations.Single(x => x.Value.Name == "Customs").Value;
+                            location.BotSpawnTimeOffMin = 1;
+                            location.BotSpawnTimeOffMax = 1;
+                            location.BotSpawnPeriodCheck = 10;
+                            location.BotStart = 0;
+                            location.BotMax = 30;
+                            foreach (var x in location.BossLocationSpawn)
+                            {
+                                x.BossChance = 100;
+                                x.ForceSpawn = true;
+                                x.IgnoreMaxBots = true;
+                            }
+                            var mmc = (MainMenuController)ReflectionHelpers.GetFieldFromType(typeof(TarkovApplication), "gclass1833_0").GetValue(app);
+                            var raidSettings = (RaidSettings)ReflectionHelpers.GetFieldFromType(typeof(MainMenuController), "raidSettings_0").GetValue(mmc);
+                            raidSettings.Apply(new RaidSettings(
+                                side: ESideType.Pmc,
+                                selectedDateTime: EDateTime.CURR,
+                                raidMode: ERaidMode.Local,
+                                timeAndWeatherSettings: new TimeAndWeatherSettings(
+                                    randomTime: false,
+                                    randomWeather: false,
+                                    cloudinessType: 0,
+                                    rainType: 0,
+                                    windSpeed: 0,
+                                    fogType: 0,
+                                    timeFlowType: 4,
+                                    hourOfDay: -1
+                                ),
+                                locationSettings: locationSettings
+                            )
+                            {
+                                BotSettings = botSettings,
+                                SelectedLocation = location
+                            });
+                            var readyButton = new WaitForButton<MatchMakerSelectionLocationScreen, DefaultUIButton>(screens[EEftScreenType.SelectLocation], "_acceptButton");
+                            yield return readyButton;
+                            readyButton.Button.OnClick.Invoke();
+
+                            {
+                                var nextButton = new WaitForButton<MatchmakerOfflineRaidScreen, DefaultUIButton>(screens[EEftScreenType.OfflineRaid], "_nextButtonSpawner");
+                                yield return nextButton;
+                                nextButton.Button.OnClick.Invoke();
+                            }
+
+                            {
+                                var nextButton = new WaitForButton<MatchmakerInsuranceScreen, DefaultUIButton>(screens[EEftScreenType.Insurance], "_nextButton");
+                                yield return nextButton;
+                                nextButton.Button.OnClick.Invoke();
+                            }
+
+                            {
+                                yield return new WaitUntil(() => MatchmakerAcceptScreenShowPatch.MatchmakerObject?.GetComponent<SITMatchmakerGUIComponent>() != null);
+                                var guiComp = MatchmakerAcceptScreenShowPatch.MatchmakerObject.GetComponent<SITMatchmakerGUIComponent>();
+                                guiComp.HostSoloRaidAndJoin(ESITProtocol.PeerToPeerUdp, EBotAmount.High);
+                            }
+
+                            if (i > 0)
+                            {
+                                yield return new WaitForSeconds(300.0f);
+                                Singleton<ISITGame>.Instance.Stop(SITMatchmaking.Profile.ProfileId, ExitStatus.Survived, "");
+
+                                {
+                                    yield return new WaitUntil(
+                                        () => screens.ContainsKey(EEftScreenType.ExitStatus) && screens[EEftScreenType.ExitStatus].gameObject.activeSelf);
+                                    var nextButton = new WaitForButton<SessionResultExitStatus, DefaultUIButton>(screens[EEftScreenType.ExitStatus], "_nextButton");
+                                    yield return nextButton;
+                                    nextButton.Button.OnClick.Invoke();
+                                }
+
+                                {
+                                    var nextButton = new WaitForButton<SessionResultKillList, DefaultUIButton>(screens[EEftScreenType.KillList], "_nextButton");
+                                    yield return nextButton;
+                                    nextButton.Button.OnClick.Invoke();
+                                }
+
+                                {
+                                    var nextButton = new WaitForButton<SessionResultStatistics, DefaultUIButton>(screens[EEftScreenType.SessionStatistics], "_nextButton");
+                                    yield return nextButton;
+                                    nextButton.Button.OnClick.Invoke();
+                                }
+
+                                {
+                                    var nextButton = new WaitForButton<SessionResultExperienceCount, DefaultUIButton>(screens[EEftScreenType.SessionExperience], "_nextButton");
+                                    yield return nextButton;
+                                    nextButton.Button.OnClick.Invoke();
+                                }
+
+                                {
+                                    var profile = app.Session.Profile;
+                                    var ic = new InventoryController(app.Session, profile, profile.Id);
+                                    var hc = new HealthControllerClass(profile.Health, ic, profile.Skills, regeneration: true);
+                                    if (HealthTreatmentScreen.IsAvailable(profile, hc, app.Session.Medic.Info))
+                                    {
+                                        var nextButton = new WaitForButton<HealthTreatmentScreen, DefaultUIButton>(screens[EEftScreenType.HealthTreatment], "_nextButton");
+                                        yield return nextButton;
+                                        nextButton.Button.OnClick.Invoke();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        Destroy(this);
+                    }
+                }
+
+                StartCoroutine(autoraid());
+            }
+        }
+    }
+
+    class WaitForButton<T, U>(UIScreen screen, string fieldName) : CustomYieldInstruction where T : UIScreen where U : class?
+    {
+        public U Button;
+
+        public override bool keepWaiting
+        {
+            get
+            {
+                Button = (U)ReflectionHelpers.GetFieldFromType(typeof(T), fieldName).GetValue(screen);
+                return Button == null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a command-line argument to start the game in autoraid mode.
Autoraid will start a few raids back-to-back in (hopefully) somewhat controlled conditions (same spawn point, same bosses, same bot settings, etc.) to be able to compare performance improvements, or find regressions more easily and in an automated fashion.

This also exposed a few race conditions that would result in player getting stuck on loading screen, that are now fixed:
- UDP client could try to connect and fail before UDP server was even started
- Game could start and try to send player sync info statuses before the UDP client was connected