### PR TITLE
Fix boss follower spawning, cultist time detection & spawning

### DIFF
--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -460,7 +460,7 @@ namespace StayInTarkov.Coop.SITGameModes
             if (SITMatchmaking.IsClient)
                 return null;
 
-            if (Bots != null && Bots.Count(x => x.Value != null && x.Value.PlayerHealthController.IsAlive) >= MaxBotCount)
+            if (Bots != null && !profile.Info.Settings.IsBossOrFollower() && Bots.Count(x => x.Value != null && x.Value.PlayerHealthController.IsAlive) >= MaxBotCount)
             {
                 Logger.LogDebug("Block spawn of Bot. Max Bot Count has been reached!");
                 return null;

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -394,16 +394,20 @@ namespace StayInTarkov.Coop.SITGameModes
             return (BotDifficulty)values.GetValue(UnityEngine.Random.Range(0, values.Length));
         }
 
-        private static int[] CultistSpawnTime = new[] { 6, 22 };
+        private static int[] CultistSpawnTime = new[] { 22, 6 };
 
         private static bool CanSpawnCultist(int hour)
         {
-            return hour <= CultistSpawnTime[0] || hour >= CultistSpawnTime[1];
+            if (hour >= CultistSpawnTime[0] && hour <= CultistSpawnTime[1])
+                return true;
+
+            return false;
         }
 
         public BossLocationSpawn[] FixBossWaveSettings(WavesSettings wavesSettings, LocationSettingsClass.Location location)
         {
             var bossLocationSpawns = location.BossLocationSpawn;
+            TimeSpan CurrentGameTime = GameDateTime.Calculate().TimeOfDay;
             if (!wavesSettings.IsBosses)
             {
                 Logger.LogDebug($"{nameof(CoopSITGame)}:{nameof(FixBossWaveSettings)}: Bosses are disabled");
@@ -415,36 +419,39 @@ namespace StayInTarkov.Coop.SITGameModes
                 Logger.LogDebug($"{nameof(FixBossWaveSettings)}:===BEFORE===");
                 Logger.LogDebug($"{nameof(FixBossWaveSettings)}:{bossLocationSpawn.ToJson()}");
 #endif
-                List<int> sourceEscortAmount;
-                try
+
+                if (!CanSpawnCultist(CurrentGameTime.Hours) && bossLocationSpawn.BossName.Contains("sectant"))
                 {
-                    sourceEscortAmount = bossLocationSpawn.BossEscortAmount.Split(',').Select(int.Parse).ToList();
-                    bossLocationSpawn.ParseMainTypesTypes();
+                    Logger.LogInfo($"Block spawn of Sectant (Cultist) in day time in hour {CurrentGameTime.Hours}!");
+                    bossLocationSpawn.BossChance = 0f;
                 }
-                catch (Exception)
-                {
-                    Logger.LogError($"{nameof(CoopSITGame)}:{nameof(FixBossWaveSettings)}: Unable to parse BossEscortAmount");
-                    continue;
-                }
-                float bossChance = bossLocationSpawn.BossChance;
-                if (CanSpawnCultist(GameWorldTime.Hour) && (bossLocationSpawn.BossType == WildSpawnType.sectantPriest || bossLocationSpawn.BossType == WildSpawnType.sectantWarrior))
-                {
-                    Logger.LogDebug($"Block spawn of Sectant (Cultist) in day time in hour {GameWorldTime.Hour}!");
-                    bossChance = -1f;
-                }
-                bossLocationSpawn.BossChance = bossChance;
-                bossLocationSpawn.BossEscortAmount = sourceEscortAmount != null ? sourceEscortAmount.Max((int x) => x).ToString() : "1";
-                if (bossLocationSpawn.Supports == null && !string.IsNullOrEmpty(bossLocationSpawn.BossEscortType) && !bossLocationSpawn.BossName.Equals("bossTagilla"))
+
+                //ArchangelWTF: boss types like 'arenaFighterEvent' can have multiple values, split these out and take the first value.
+                //We could maybe do some fancy randomization here at some point to get a number in between the two values, but for now this works.
+                if (bossLocationSpawn.BossEscortAmount.Contains(","))
+                    bossLocationSpawn.BossEscortAmount = bossLocationSpawn.BossEscortAmount.Split(',')[0];
+
+                int EscortAmount = Convert.ToInt32(bossLocationSpawn.BossEscortAmount);
+
+                if (bossLocationSpawn.Supports == null && !string.IsNullOrEmpty(bossLocationSpawn.BossEscortType) && EscortAmount > 0)
                 {
                     Logger.LogDebug($"bossLocationSpawn.Supports is Null. Attempt to create them.");
 
-                    bossLocationSpawn.Supports = new WildSpawnSupports[1];
-                    bossLocationSpawn.Supports[0] = new WildSpawnSupports();
-                    bossLocationSpawn.Supports[0].BossEscortDifficult = new[] { "normal" };
-                    bossLocationSpawn.Supports[0].BossEscortAmount = 3;
-                    if (Enum.TryParse<WildSpawnType>(bossLocationSpawn.BossEscortType, out var t))
-                        bossLocationSpawn.Supports[0].BossEscortType = t;
+                    Enum.TryParse<WildSpawnType>(bossLocationSpawn.BossEscortType, out var EscortType);
+
+                    bossLocationSpawn.Supports = new WildSpawnSupports[EscortAmount];
+
+                    for (int i = 0; i < EscortAmount; i++)
+                    {
+                        bossLocationSpawn.Supports[i] = new WildSpawnSupports
+                        {
+                            BossEscortDifficult = new[] { bossLocationSpawn.BossEscortDifficult },
+                            BossEscortAmount = 1,
+                            BossEscortType = EscortType
+                        };
+                    }
                 }
+
 #if DEBUG
                 Logger.LogDebug($"{nameof(FixBossWaveSettings)}:===AFTER===");
                 Logger.LogDebug($"{nameof(FixBossWaveSettings)}:{bossLocationSpawn.ToJson()}");
@@ -466,7 +473,7 @@ namespace StayInTarkov.Coop.SITGameModes
                 return null;
             }
 
-            if (GameDateTime.Calculate().TimeOfDay < new TimeSpan(20, 0, 0) && profile.Info != null && profile.Info.Settings != null
+            if (!CanSpawnCultist(GameDateTime.Calculate().TimeOfDay.Hours) && profile.Info != null && profile.Info.Settings != null
                 && (profile.Info.Settings.Role == WildSpawnType.sectantPriest || profile.Info.Settings.Role == WildSpawnType.sectantWarrior)
                 )
             {

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -422,7 +422,7 @@ namespace StayInTarkov.Coop.SITGameModes
 
                 if (!CanSpawnCultist(CurrentGameTime.Hours) && bossLocationSpawn.BossName.Contains("sectant"))
                 {
-                    Logger.LogInfo($"Block spawn of Sectant (Cultist) in day time in hour {CurrentGameTime.Hours}!");
+                    Logger.LogDebug($"Block spawn of Sectant (Cultist) in day time in hour {CurrentGameTime.Hours}!");
                     bossLocationSpawn.BossChance = 0f;
                 }
 


### PR DESCRIPTION
This commit fixes the following:

- Boss follower spawning
- Detection of time for cultists to spawn
- Allowing bosses and their followers to bypass the max spawn amount

I had to refactor this a bit due to for some reason Tarkov not liking to take a different 'BossEscortAmount' under one support, even if it was for example set to spawn 8 escorts of one type it would just only spawn one, now each escort will have a support generated for them.