### PR TITLE
[devtools] Add freecam to console commands

### DIFF
--- a/Source/Coop/FreeCamera/FreeCameraController.cs
+++ b/Source/Coop/FreeCamera/FreeCameraController.cs
@@ -173,7 +173,7 @@ namespace StayInTarkov.Coop.FreeCamera
         /// <summary>
         /// Hides the main UI (health, stamina, stance, hotbar, etc.)
         /// </summary>
-        private void ToggleUi()
+        public void ToggleUi()
         {
             // Check if we're currently in a raid
             if (GetLocalPlayerFromWorld() == null)

--- a/Source/UI/ConsoleCommands.cs
+++ b/Source/UI/ConsoleCommands.cs
@@ -4,6 +4,7 @@ using EFT.Console.Core;
 using EFT.UI;
 using EFT.Weather;
 using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.FreeCamera;
 using StayInTarkov.Coop.SITGameModes;
 using System;
 using System.IO;
@@ -184,6 +185,34 @@ namespace StayInTarkov.UI
                     object value = property.GetValue(weatherDebug);
                     EFT.UI.ConsoleScreen.Log($"{property.Name}: {value}");
                 }
+            }
+            catch (Exception ex)
+            {
+                ConsoleScreen.LogException(ex);
+            }
+        }
+
+        [ConsoleCommand("freecam.enable", "", null, "Activates / Deactivates freecam", [])]
+        public static void Freecam_Enable()
+        {
+            try
+            {
+                FreeCameraController CameraController = Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<FreeCameraController>();
+                CameraController.ToggleCamera();
+            }
+            catch(Exception ex)
+            {
+                ConsoleScreen.LogException(ex);
+            }
+        }
+
+        [ConsoleCommand("freecam.toggleui", "", null, "Activates / Deactivates freecam's ability to hide the UI", [])]
+        public static void Freecam_ToggleUI()
+        {
+            try
+            {
+                FreeCameraController CameraController = Singleton<GameWorld>.Instance.gameObject.GetOrAddComponent<FreeCameraController>();
+                CameraController.ToggleUi();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Since freecam became unavailable in the one of the newer builds, re-add this functionality as a console command.

Are we still considering to use freecam outside of development builds? If not we could wrap the entire free .Camera namespace in `#IF DEBUG` and move the FadeBlackScreenPatch to StayInTarkov.UI