### PR TITLE
[fix] remove custom processing around boss/scav spawns

### DIFF
--- a/Source/AkiSupport/Custom/BossSpawnChancePatch.cs
+++ b/Source/AkiSupport/Custom/BossSpawnChancePatch.cs
@@ -1,0 +1,58 @@
+using EFT;
+using StayInTarkov;
+using System.Linq;
+using System.Reflection;
+
+namespace Aki.Custom.Patches
+{
+    /// <summary>
+    /// Created by: SPT-Aki
+    /// Link: https://dev.sp-tarkov.com/SPT-AKI/Modules/src/branch/master/project/Aki.Custom/Patches/BossSpawnChancePatch.cs
+    /// Boss spawn chance is 100%, all the time, this patch adjusts the chance to the maps boss wave value
+    /// </summary>
+    public class BossSpawnChancePatch : ModulePatch
+    {
+        private static float[] _bossSpawnPercent;
+
+        protected override MethodBase GetTargetMethod()
+        {
+            var desiredType = typeof(LocalGame);
+            var desiredMethod = desiredType
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .SingleOrDefault(IsTargetMethod);
+
+            Logger.LogDebug($"{this.GetType().Name} Type: {desiredType.Name}");
+            Logger.LogDebug($"{this.GetType().Name} Method: {desiredMethod?.Name ?? "NOT FOUND"}");
+
+            return desiredMethod;
+        }
+
+        private static bool IsTargetMethod(MethodInfo mi)
+        {
+            var parameters = mi.GetParameters();
+            return (parameters.Length == 2
+                && parameters[0].Name == "wavesSettings"
+                && parameters[1].Name == "bossLocationSpawn");
+        }
+
+        [PatchPrefix]
+        private static void PatchPrefix(BossLocationSpawn[] bossLocationSpawn)
+        {
+            _bossSpawnPercent = bossLocationSpawn.Select(s => s.BossChance).ToArray();
+        }
+
+        [PatchPostfix]
+        private static void PatchPostfix(ref BossLocationSpawn[] __result)
+        {
+            if (__result.Length != _bossSpawnPercent.Length)
+            {
+                return;
+            }
+
+            for (var i = 0; i < _bossSpawnPercent.Length; i++)
+            {
+                __result[i].BossChance = _bossSpawnPercent[i];
+            }
+        }
+    }
+}

--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -378,6 +378,7 @@ namespace StayInTarkov
         private static void EnableSPPatches_Bots(BepInEx.Configuration.ConfigFile config)
         {
             new CoreDifficultyPatch().Enable();
+            new BossSpawnChancePatch().Enable();
             new BotDifficultyPatch().Enable();
             new BotSettingsRepoClassIsFollowerFixPatch().Enable();
             new BotSelfEnemyPatch().Enable();


### PR DESCRIPTION
This removes the custom code we have around boss spawning since we probably have no business handling that ourselves and so that we can be more inline with SPT and mods.
Tested bosses and scavs are spawning fine, no cultist during the day.