### PR TITLE
Process RestoreBodyPart in Packet rather than Patch

### DIFF
--- a/Source/Coop/NetworkPacket/Player/Health/RestoreBodyPartPacket.cs
+++ b/Source/Coop/NetworkPacket/Player/Health/RestoreBodyPartPacket.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using EFT.HealthSystem;
+using StayInTarkov.Coop.Components.CoopGameComponents;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UnityEngine;
+using static GClass2416<EFT.HealthSystem.ActiveHealthController.GClass2415>;
 
 namespace StayInTarkov.Coop.NetworkPacket.Player.Health
 {
@@ -12,10 +13,7 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Health
         public string BodyPart { get; set; }
         public float HealthPenalty { get; set; }
 
-        public RestoreBodyPartPacket() : base()
-        {
-            Method = "RestoreBodyPart";
-        }
+        public RestoreBodyPartPacket() : base("", nameof(RestoreBodyPartPacket)) { }
 
         public override byte[] Serialize()
         {
@@ -34,6 +32,65 @@ namespace StayInTarkov.Coop.NetworkPacket.Player.Health
             BodyPart = reader.ReadString();
             HealthPenalty = reader.ReadSingle();
             return this;
+        }
+
+        public override void Process()
+        {
+            if (!SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                return;
+
+            if (!coopGameComponent.Players.ContainsKey(ProfileId))
+                return;
+
+            var player = coopGameComponent.Players[ProfileId];
+
+            if (player.HealthController != null && player.HealthController.IsAlive)
+            {
+                StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(PlayerInformationPacket)}:Replicated: Calling RestoreBodyPart");
+
+                var bodyPart = (EBodyPart)Enum.Parse(typeof(EBodyPart), BodyPart, true);
+                var bodyPartState = GetBodyPartDictionary(player)[bodyPart];
+
+                if (bodyPartState == null)
+                {
+                    StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(PlayerInformationPacket)}: Could not retrieve {player.ProfileId}'s Health State for Body Part {bodyPart}");
+                    return;
+                }
+
+                if (bodyPartState.IsDestroyed)
+                {
+                    bodyPartState.IsDestroyed = false;
+                    var healthPenalty = HealthPenalty + (1f - HealthPenalty) * player.Skills.SurgeryReducePenalty;
+                    StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(PlayerInformationPacket)}:HealthPenalty::" + healthPenalty);
+                    bodyPartState.Health = new HealthValue(1f, Mathf.Max(1f, Mathf.Ceil(bodyPartState.Health.Maximum * healthPenalty)), 0f);
+
+                    player.ExecuteSkill(new Action<float>(player.Skills.SurgeryAction.Complete));
+                    player.UpdateSpeedLimitByHealth();
+                }
+            }
+        }
+
+        private Dictionary<EBodyPart, BodyPartState> GetBodyPartDictionary(EFT.Player player)
+        {
+            try
+            {
+                var bodyPartDict
+                = ReflectionHelpers.GetFieldOrPropertyFromInstance<Dictionary<EBodyPart, BodyPartState>>
+                (player.PlayerHealthController, "Dictionary_0", false);
+                if (bodyPartDict == null)
+                {
+                    StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(PlayerInformationPacket)}:Could not retrieve {player.ProfileId}'s Health State Dictionary");
+                    return null;
+                }
+
+                return bodyPartDict;
+            }
+            catch (Exception ex)
+            {
+                StayInTarkovHelperConstants.Logger.LogError($"{nameof(PlayerInformationPacket)}: {ex}");
+            }
+
+            return null;
         }
     }
 }

--- a/Source/Coop/Player/Health/RestoreBodyPartPatch.cs
+++ b/Source/Coop/Player/Health/RestoreBodyPartPatch.cs
@@ -59,80 +59,8 @@ namespace StayInTarkov.Coop.Player.Health
             GameClient.SendData(restoreBodyPartPacket.Serialize());
         }
 
-
         public override void Replicated(EFT.Player player, Dictionary<string, object> dict)
         {
-            RestoreBodyPartPacket restoreBodyPartPacket = new();
-            restoreBodyPartPacket.Deserialize((byte[])dict["data"]);
-
-            if (HasProcessed(GetType(), player, restoreBodyPartPacket))
-                return;
-
-            if (player.HealthController != null && player.HealthController.IsAlive)
-            {
-                Logger.LogDebug("Replicated: Calling RestoreBodyPart");
-                Logger.LogDebug(restoreBodyPartPacket.ToJson());
-
-                if (dict == null)
-                {
-                    Logger.LogError($"Dictionary packet is null?");
-                    return;
-
-                }
-                //Logger.LogInfo(dict.ToJson());
-
-                var bodyPart = (EBodyPart)Enum.Parse(typeof(EBodyPart), restoreBodyPartPacket.BodyPart, true);
-                var bodyPartState = GetBodyPartDictionary(player)[bodyPart];
-
-                if (bodyPartState == null)
-                {
-                    Logger.LogError($"Could not retreive {player.ProfileId}'s Health State for Body Part {restoreBodyPartPacket.BodyPart}");
-                    return;
-                }
-
-                if (bodyPartState.IsDestroyed)
-                {
-                    bodyPartState.IsDestroyed = false;
-                    var healthPenalty = restoreBodyPartPacket.HealthPenalty + (1f - restoreBodyPartPacket.HealthPenalty) * player.Skills.SurgeryReducePenalty;
-                    Logger.LogDebug("RestoreBodyPart::HealthPenalty::" + healthPenalty);
-                    bodyPartState.Health = new HealthValue(1f, Mathf.Max(1f, Mathf.Ceil(bodyPartState.Health.Maximum * healthPenalty)), 0f);
-
-                    player.ExecuteSkill(new Action<float>(player.Skills.SurgeryAction.Complete));
-                    player.UpdateSpeedLimitByHealth();
-                }
-            }
         }
-
-        private Dictionary<EBodyPart, AHealthController.BodyPartState> GetBodyPartDictionary(EFT.Player player)
-        {
-            try
-            {
-                var bodyPartDict
-                = ReflectionHelpers.GetFieldOrPropertyFromInstance<Dictionary<EBodyPart, AHealthController.BodyPartState>>
-                (player.PlayerHealthController, "Dictionary_0", false);
-                if (bodyPartDict == null)
-                {
-                    Logger.LogError($"Could not retreive {player.ProfileId}'s Health State Dictionary");
-                    return null;
-                }
-                //Logger.LogInfo(bodyPartDict.ToJson());
-                return bodyPartDict;
-            }
-            catch (Exception)
-            {
-
-                var field = ReflectionHelpers.GetFieldFromType(player.PlayerHealthController.GetType(), "Dictionary_0");
-                Logger.LogError(field);
-                var type = field.DeclaringType;
-                Logger.LogError(type);
-                var val = field.GetValue(player.PlayerHealthController);
-                Logger.LogError(val);
-                var valType = field.GetValue(player.PlayerHealthController).GetType();
-                Logger.LogError(valType);
-            }
-
-            return null;
-        }
-
     }
 }


### PR DESCRIPTION
This fixes the issue of RestoreBodyPart not working in development.

Todo: Sometimes at the end of the raid the health is a bit out of sync with what's been healed here, not sure if this is due to this patch or some other code.