### PR TITLE
Clean-up DataProcessing and AkiBackend

### DIFF
--- a/Source/AkiSupport/Custom/BotDifficultyPatch.cs
+++ b/Source/AkiSupport/Custom/BotDifficultyPatch.cs
@@ -1,8 +1,8 @@
 using EFT;
 using StayInTarkov.Networking;
+using System;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace StayInTarkov.AkiSupport.Custom
 {
@@ -24,7 +24,14 @@ namespace StayInTarkov.AkiSupport.Custom
         [PatchPrefix]
         private static bool PatchPrefix(ref string __result, BotDifficulty botDifficulty, WildSpawnType role)
         {
-            __result = AkiBackendCommunication.Instance.GetJsonBLOCKING($"/singleplayer/settings/bot/difficulty/{role}/{botDifficulty}");
+            try
+            {
+                __result = AkiBackendCommunication.Instance.GetJsonBLOCKING($"/singleplayer/settings/bot/difficulty/{role}/{botDifficulty}", 15000);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Could not fetch bot difficulty: {ex}");
+            }
             return string.IsNullOrWhiteSpace(__result);
         }
     }

--- a/Source/AkiSupport/Custom/CoreDifficultyPatch.cs
+++ b/Source/AkiSupport/Custom/CoreDifficultyPatch.cs
@@ -1,4 +1,5 @@
 using StayInTarkov.Networking;
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -22,7 +23,14 @@ namespace StayInTarkov.AkiSupport.Custom
         [PatchPrefix]
         private static bool PatchPrefix(ref string __result)
         {
-            __result = AkiBackendCommunication.Instance.GetJsonBLOCKING("/singleplayer/settings/bot/difficulty/core/core");
+            try
+            {
+                __result = AkiBackendCommunication.Instance.GetJsonBLOCKING("/singleplayer/settings/bot/difficulty/core/core", 15000);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Could not fetch bot core difficulty: {ex}");
+            }
             return string.IsNullOrWhiteSpace(__result);
         }
     }

--- a/Source/Coop/CoopPatches.cs
+++ b/Source/Coop/CoopPatches.cs
@@ -114,8 +114,6 @@ namespace StayInTarkov.Coop
                 GameObject.DestroyImmediate(coopGameComponent);
             }
 
-            AkiBackendCommunication.Instance.WebSocketClose();
-
             EnableDisablePatches();
         }
     }

--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -279,7 +279,7 @@ namespace StayInTarkov.Networking
             Ping = (ushort)(ServerPingSmooth.Count > 0 ? Math.Round(ServerPingSmooth.Average()) : 1);
         }
 
-        private async Task<byte[]?> AsyncRequestFromPath(string path, HttpMethod method, string? data = null, int timeout = 9999, bool debug = false)
+        private async Task<byte[]?> AsyncRequestFromPath(string path, HttpMethod method, string? data = null, int timeout = DEFAULT_TIMEOUT_MS, bool debug = false)
         {
             if (!Uri.IsWellFormedUriString(path, UriKind.Absolute))
             {
@@ -289,7 +289,7 @@ namespace StayInTarkov.Networking
             return await AsyncRequest(new Uri(path), method, data, timeout, debug);
         }
 
-        private async Task<byte[]?> AsyncRequest(Uri uri, HttpMethod method, string? data = null, int timeout = 9999, bool debug = false)
+        private async Task<byte[]?> AsyncRequest(Uri uri, HttpMethod method, string? data = null, int timeout = DEFAULT_TIMEOUT_MS, bool debug = false)
         {
             HttpRequestMessage req = new(method, uri);
 
@@ -342,15 +342,15 @@ namespace StayInTarkov.Networking
             return await AsyncRequestFromPath(url, HttpMethod.Get, data: null, timeout);
         }
 
-        public async Task<string> GetJsonAsync(string url)
+        public async Task<string> GetJsonAsync(string url, int timeout = DEFAULT_TIMEOUT_MS)
         {
-            var bytes = await AsyncRequestFromPath(url, HttpMethod.Get);
+            var bytes = await AsyncRequestFromPath(url, HttpMethod.Get, data: null, timeout);
             return Encoding.UTF8.GetString(bytes);
         }
 
-        public string GetJsonBLOCKING(string url)
+        public string GetJsonBLOCKING(string url, int timeout = DEFAULT_TIMEOUT_MS)
         {
-            return Task.Run(() => GetJsonAsync(url)).GetAwaiter().GetResult();
+            return Task.Run(() => GetJsonAsync(url, timeout)).GetAwaiter().GetResult();
         }
 
         public async Task<string> PostJsonAsync(string url, string data, int timeout = DEFAULT_TIMEOUT_MS, int retryAttempts = 5, bool debug = false)

--- a/Source/Networking/GameClientTCPRelay.cs
+++ b/Source/Networking/GameClientTCPRelay.cs
@@ -1,4 +1,5 @@
-﻿using StayInTarkov.Coop.Matchmaker;
+﻿using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.Matchmaker;
 using StayInTarkov.Coop.NetworkPacket;
 using System;
 using System.Collections.Concurrent;
@@ -27,12 +28,15 @@ namespace StayInTarkov.Networking
 
         void Awake()
         {
-            AkiBackendCommunication.Instance.WebSocketClose();
-            AkiBackendCommunication.Instance.WebSocketCreate(SITMatchmaking.Profile);
         }
 
         void Start()
         {
+            AkiBackendCommunication.Instance.WebSocketCreate(GetComponent<SITGameComponent>(), SITMatchmaking.Profile.Id);
+        }
+        void OnDestroy()
+        {
+            AkiBackendCommunication.Instance.WebSocketClose();
         }
 
         void Update()

--- a/Source/Networking/GameClientUDP.cs
+++ b/Source/Networking/GameClientUDP.cs
@@ -180,12 +180,12 @@ namespace StayInTarkov.Networking
         {
             if (channelNumber == SITGameServerClientDataProcessing.FLATBUFFER_CHANNEL_NUM)
             {
-                Singleton<SITGameServerClientDataProcessing>.Instance.ProcessFlatBuffer(reader.GetRemainingBytes());
+                SITGameServerClientDataProcessing.ProcessFlatBuffer(GetComponent<SITGameComponent>(), reader.GetRemainingBytes());
             }
             else
             {
                 var bytes = reader.GetRemainingBytes();
-                Singleton<SITGameServerClientDataProcessing>.Instance.ProcessPacketBytes(bytes);
+                SITGameServerClientDataProcessing.ProcessPacketBytes(GetComponent<SITGameComponent>(), bytes);
             }
         }
 


### PR DESCRIPTION
To be merged in after #292 

- Part 2 of massive clean-up
- More static classes = less state to manage and less "place-oriented" / "rendez-vous" oriented programming -> less things that can go wrong
- Last thing left is to move the in-raid TCP Relay WebSocket out in a new class (probably `GameClientTCPRelay`) to manage lifecycle in a less awkward way which is not too urgent