### PR TITLE
Replicate bot despawning to client when host despawns AI

### DIFF
--- a/Source/Coop/AI/BotDespawnPatch.cs
+++ b/Source/Coop/AI/BotDespawnPatch.cs
@@ -1,0 +1,45 @@
+﻿using EFT;
+using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.Matchmaker;
+using StayInTarkov.Coop.NetworkPacket.AI;
+using StayInTarkov.Networking;
+using System.Reflection;
+
+namespace StayInTarkov.Coop.AI
+{
+    /// <summary>
+    /// Goal: Despawning bots between Server and Client is broken, this patch aims to fix that by patching DestroyInfo to send a packet once it has ran.
+    /// </summary>
+    internal class BotDespawnPatch : ModulePatch
+    {
+        private static readonly string methodName = "DestroyInfo";
+
+        protected override MethodBase GetTargetMethod()
+        {
+            return typeof(BotsController).GetMethod(methodName);
+        }
+
+        [PatchPrefix]
+        private static bool PatchPrefix(EFT.Player player)
+        {
+            return false;
+        }
+
+        [PatchPostfix]
+        public static void Postfix(EFT.Player player)
+        {
+            if (SITMatchmaking.IsClient)
+                return;
+
+            if (!SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                return;
+
+            coopGameComponent.ProfileIdsAI.Remove(player.ProfileId);
+
+            DespawnAIPacket packet = new();
+            packet.AIProfileId = player.ProfileId;
+
+            GameClient.SendData(packet.Serialize());
+        }
+    }
+}

--- a/Source/Coop/CoopPatches.cs
+++ b/Source/Coop/CoopPatches.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.AI;
 
 namespace StayInTarkov.Coop
 {
@@ -55,7 +56,10 @@ namespace StayInTarkov.Coop
             var enablePatches = true;
 
             if (!NoMRPPatches.Any())
+            {
                 NoMRPPatches.Add(new LootableContainer_Interact_Patch());
+                NoMRPPatches.Add(new BotDespawnPatch());
+            }
 
             foreach (var patch in NoMRPPatches)
             {

--- a/Source/Coop/NetworkPacket/AI/DespawnAIPacket.cs
+++ b/Source/Coop/NetworkPacket/AI/DespawnAIPacket.cs
@@ -1,0 +1,61 @@
+﻿using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.NetworkPacket.Player;
+using System;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+namespace StayInTarkov.Coop.NetworkPacket.AI
+{
+    public class DespawnAIPacket : BasePacket
+    {
+        public string AIProfileId { get; set; }
+
+        public DespawnAIPacket() : base(nameof(DespawnAIPacket))
+        {
+        }
+
+        public override byte[] Serialize()
+        {
+            var ms = new MemoryStream();
+            using BinaryWriter writer = new BinaryWriter(ms);
+            WriteHeader(writer);
+            writer.Write(AIProfileId);
+            return ms.ToArray();
+        }
+
+        public override ISITPacket Deserialize(byte[] bytes)
+        {
+            using BinaryReader reader = new BinaryReader(new MemoryStream(bytes));
+            ReadHeader(reader);
+            AIProfileId = reader.ReadString();
+            return this;
+        }
+
+        public override void Process()
+        {
+            if (!SITGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                return;
+
+#if DEBUG
+            StayInTarkovHelperConstants.Logger.LogInfo($"{nameof(DespawnAIPacket)}: {AIProfileId}");
+#endif
+
+            if (!coopGameComponent.ProfileIdsAI.Contains(AIProfileId))
+                return;
+
+            try
+            {
+                EFT.Player Bot = coopGameComponent.Players[AIProfileId];
+                Bot.Dispose();
+                coopGameComponent.ProfileIdsAI.Remove(AIProfileId);
+                UnityEngine.Object.DestroyImmediate(Bot);
+                UnityEngine.Object.Destroy(Bot);
+            }
+            catch(Exception ex)
+            {
+                StayInTarkovHelperConstants.Logger.LogError($"{nameof(DespawnAIPacket)}: {ex}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This merge request fixes the issue of mods despawning AI (SAIN, SWAG + Donuts) and the state between host and clients going out of sync due to it.

This also adds a few console commands to easily replicate this behavior and be able to test it, teleport bots to you when you are both in-game with host and client and then despawn them.