### PR TITLE
New Server Endpoint Usage

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -520,7 +520,7 @@ namespace StayInTarkov.Coop.Components
                     int playerCount = int.Parse(match["PlayerCount"].ToString());
                     string protocol = (string)match["Protocol"];
 
-                    if (playerCount > 0 || protocol == "PeerToPeerUdp")
+                    if (playerCount > 0)
                     {
                         // Display Host Name with "Raid" label
                         GUI.Label(new UnityEngine.Rect(10, yPos, cellWidth - separatorWidth, cellHeight), $"{match["HostName"]} Raid", labelStyle);

--- a/Source/Coop/SITGameModes/CoopSITGame.cs
+++ b/Source/Coop/SITGameModes/CoopSITGame.cs
@@ -643,6 +643,12 @@ namespace StayInTarkov.Coop.SITGameModes
                     Logger.LogDebug("Sending Connect to Relay");
                     GameClient.SendData(Encoding.UTF8.GetBytes(j.ToString()));
                     break;
+                case ESITProtocol.PeerToPeerUdp:
+                    JObject js = new JObject();
+                    js.Add("serverId",  SITGameComponent.GetServerId());
+                    js.Add("profileId", profile.ProfileId);
+                    AkiBackendCommunication.Instance.PostJsonAndForgetAsync("/coop/raid/udp/join", js.SITToJson());
+                    break;
             }
            
 


### PR DESCRIPTION
This is in relation to [#46 on SIT.Aki-Server-Mod](https://github.com/stayintarkov/SIT.Aki-Server-Mod/pull/46). This uses the newly added endpoint for UDP clients to announce their join intent so that we can track the number of players to display in the server browser and so the fix for joining too soon can be applied to UDP P2P raids.