### PR TITLE
Fast backpack replication & PlayerOwnerInventoryController change

### DIFF
--- a/Source/Coop/Controllers/CoopInventory/CoopInventoryController.cs
+++ b/Source/Coop/Controllers/CoopInventory/CoopInventoryController.cs
@@ -59,6 +59,7 @@ namespace StayInTarkov.Coop.Controllers.CoopInventory
             return id;
         }
 
+        public void IgnoreOperation(ushort OperationToIgnore) => IgnoreOperations.Add(OperationToIgnore);
 
         public override void Execute(AbstractInventoryOperation operation, [CanBeNull] Callback callback)
         {
@@ -84,6 +85,15 @@ namespace StayInTarkov.Coop.Controllers.CoopInventory
         /// <returns></returns>
         protected virtual void SendExecuteOperationToServer(AbstractInventoryOperation operation)
         {
+            if(IgnoreOperations.Contains(operation.Id))
+            {
+                StayInTarkovHelperConstants.Logger.LogWarning($"Ignoring operation: {operation.Id}");
+
+                //Ignore the operation once.
+                IgnoreOperations.Remove(operation.Id);
+                return;
+            }
+
             var itemId = "";
             var templateId = "";
             ushort stackObjectsCount = 1;

--- a/Source/Coop/Controllers/CoopInventory/CoopInventoryControllerClient.cs
+++ b/Source/Coop/Controllers/CoopInventory/CoopInventoryControllerClient.cs
@@ -7,12 +7,11 @@ using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using static UnityEngine.UIElements.StyleVariableResolver;
 
 namespace StayInTarkov.Coop.Controllers.CoopInventory
 {
     public sealed class CoopInventoryControllerClient
-        : EFT.Player.PlayerOwnerInventoryController, ICoopInventoryController, IIdGenerator
+        : EFT.Player.PlayerInventoryController, ICoopInventoryController, IIdGenerator
     {
         ManualLogSource BepInLogger { get; set; }
 

--- a/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
+++ b/Source/Coop/Controllers/HandControllers/SITFirearmController.cs
@@ -2,15 +2,11 @@
 using Comfort.Common;
 using EFT;
 using EFT.InventoryLogic;
-using EFT.UI;
+using StayInTarkov.Coop.Controllers.CoopInventory;
+using StayInTarkov.Coop.NetworkPacket.Player.Inventory;
 using StayInTarkov.Coop.NetworkPacket.Player.Weapons;
-using StayInTarkov.Coop.Players;
 using StayInTarkov.Networking;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace StayInTarkov.Coop.Controllers.HandControllers
@@ -27,8 +23,69 @@ namespace StayInTarkov.Coop.Controllers.HandControllers
 
         public override void Execute(IOperation1 operation, Callback callback)
         {
+            //Apply the same checks BSG does before invoking DropBackpackOperationInvoke
+            if (!method_18(operation))
+            {
+                IOneItemOperation ProperOperation = TryGetIOneItemOperation(operation);
+
+                if (ProperOperation != null && IsAnimatedSlot(ProperOperation))
+                {   
+                    BepInLogger.LogInfo($"{nameof(SITFirearmController)}:Attempt to quickly replicate a backpack drop");
+
+                    PlayerInventoryDropBackpackPacket packet = new();
+                    packet.ProfileId = _player.ProfileId;
+
+                    GameClient.SendData(packet.Serialize());
+
+                    //Do not send the current operation to the inventory server as the packet we just sent already handles this.
+                    AbstractInventoryOperation AbstractOperation = (AbstractInventoryOperation)operation;
+                    var CoopInventoryController = ((CoopInventoryController)ItemFinder.GetPlayerInventoryController(_player));
+                    CoopInventoryController.IgnoreOperation(AbstractOperation.Id);
+                }
+                
+            }
+
             BepInLogger.LogDebug($"{nameof(SITFirearmController)}:{nameof(Execute)}:{operation}");
             base.Execute(operation, callback);
+        }
+
+        private IOneItemOperation TryGetIOneItemOperation(IOperation1 operation)
+        {
+            if (!(operation is IOneItemOperation ItemOperation))
+                return null;
+
+            return ItemOperation;
+        }
+
+        //Replicate IsAnimatedSlot as this method is not available to us.
+        private bool IsAnimatedSlot(IOneItemOperation ItemOperation)
+        {
+            try
+            {
+                if (ItemOperation == null)
+                    return false;
+
+                var PlyInventoryController = (InventoryControllerClass)ItemFinder.GetPlayerInventoryController(_player);
+
+                //We either picked something up or something is messed up, dont continue in either case.
+                if (PlyInventoryController == null || ItemOperation.From1 == null)
+                {
+                    return false;
+                }
+
+                //I'm not doing BSG's dumb looping code here (At least that's what it looks like in ILSpy) for only one item in an array
+                if (PlyInventoryController.Inventory.Equipment.GetSlot(EquipmentSlot.Backpack) == ItemOperation.From1.Container)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            catch(Exception ex)
+            {
+                BepInLogger.LogError($"{nameof(SITFirearmController)}:{nameof(IsAnimatedSlot)}:{ex}");
+                return false;
+            }
         }
 
         public override void Drop(float animationSpeed, Action callback, bool fastDrop = false, Item nextControllerItem = null)

--- a/Source/Coop/NetworkPacket/Player/Inventory/PlayerInventoryDropBackpackPacket.cs.cs
+++ b/Source/Coop/NetworkPacket/Player/Inventory/PlayerInventoryDropBackpackPacket.cs.cs
@@ -1,0 +1,31 @@
+﻿using StayInTarkov.Coop.Players;
+
+namespace StayInTarkov.Coop.NetworkPacket.Player.Inventory
+{
+    /// <summary>
+    /// Goal: Backpack dropping in Polymorphing an inventory operation is too slow and only happens after the animation has already played
+    /// This causees an issue because the host still has to sync up by the time the client might have already picked up a new bag.
+    /// This Packet and the code referencing it fixes that.
+    /// </summary>
+    internal class PlayerInventoryDropBackpackPacket : ItemPlayerPacket
+    {
+        public PlayerInventoryDropBackpackPacket() : base("", "", "", nameof(PlayerInventoryDropBackpackPacket))
+        {
+        }
+
+        public override byte[] Serialize()
+        {
+            return base.Serialize();
+        }
+
+        public override ISITPacket Deserialize(byte[] bytes)
+        {
+            return base.Deserialize(bytes);
+        }
+
+        protected override void Process(CoopPlayerClient client)
+        {
+            client.DropBackpack();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds / changes the following:

- Sets PlayerOwnerInventoryController to PlayerInventoryController to avoid situations like all guns jamming, this seemingly has no other regression from when I tested it
- Replicates dropping a backpack as soon as possible to other clients rather than when the animation is complete