### PR TITLE
temp re-enable "AddSptBotSettingsPatch"

### DIFF
--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -95,7 +95,7 @@ namespace StayInTarkov
 
         private string[] SPTPatchesToRemove => [
             "AddEnemyToAllGroupsInBotZonePatch",
-            "AddSptBotSettingsPatch", // Requires Aki.PrePatch
+         //   "AddSptBotSettingsPatch", // Requires Aki.PrePatch
             "AirdropPatch",
             "AirdropFlarePatch",
             "AmmoUsedCounterPatch",


### PR DESCRIPTION
disabling this breaks scav raids' PMCs when they die they just stand there. and proceed to throw

```KeyNotFoundException: The given key was not present in the dictionary.
  at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) [0x0001e] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at (wrapper dynamic-method) BotSettingsRepoClass.DMD<BotSettingsRepoClass::IsHostileToEverybody>(EFT.WildSpawnType)
  at EFT.BotOwner.method_9 (DamageInfo damageInfo, EBodyPart bodyType, System.Single damageReducedByArmor) [0x0005e] in <448e567fc8c849f8a66327014c6f134c>:0 
  at EFT.BotOwner.method_3 (EFT.Player player, EFT.IPlayer lastAggressor, DamageInfo lastDamageInfo, EBodyPart lastBodyPart) [0x00010] in <448e567fc8c849f8a66327014c6f134c>:0 
  at EFT.Player.OnDead (EFT.EDamageType damageType) [0x00063] in <448e567fc8c849f8a66327014c6f134c>:0 
  at StayInTarkov.Coop.Players.CoopPlayer.OnDead (EFT.EDamageType damageType) [0x00000] in <d298dd55d7eb4df9971d9fca4dd986c3>:0 
  at (wrapper delegate-invoke) System.Action`1[EFT.EDamageType].invoke_void_T(EFT.EDamageType)
  at EFT.HealthSystem.ActiveHealthController.Kill (EFT.EDamageType damageType) [0x00021] in <448e567fc8c849f8a66327014c6f134c>:0 
  at EFT.HealthSystem.ActiveHealthController.method_20 (EBodyPart bodyPart, EFT.EDamageType damageType) [0x00010] in <448e567fc8c849f8a66327014c6f134c>:0 
  at (wrapper dynamic-method) EFT.HealthSystem.ActiveHealthController.DMD<EFT.HealthSystem.ActiveHealthController::DestroyBodyPart>(EFT.HealthSystem.ActiveHealthController,EBodyPart,EFT.EDamageType)
  at (wrapper dynamic-method) EFT.HealthSystem.ActiveHealthController.DMD<EFT.HealthSystem.ActiveHealthController::ApplyDamage>(EFT.HealthSystem.ActiveHealthController,EBodyPart,single,DamageInfo)
  at (wrapper dynamic-method) EFT.Player.DMD<EFT.Player::ApplyDamageInfo>(EFT.Player,DamageInfo,EBodyPart,EBodyPartColliderType,single)
  at StayInTarkov.Coop.Players.CoopPlayer.<>n__0 (DamageInfo damageInfo, EBodyPart bodyPartType, EBodyPartColliderType colliderType, System.Single absorbed) [0x00000] in <d298dd55d7eb4df9971d9fca4dd986c3>:0 
  at StayInTarkov.Coop.Players.CoopPlayer+<ReceiveDamageFromServerCR>d__12.MoveNext () [0x00116] in <d298dd55d7eb4df9971d9fca4dd986c3>:0 
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00026] in <ca21460feb9c47d0ac337b9893474cc6>:0
  ```
  
## how to repro
- scav in
- kill any pmc
- pmc now will get into a stuck state, if they are firing weapon they'll keep firing (sound/animation etc), technically they are dead but you can't loot them.
- only happens in scav raids, pmc raids have no such issue.

## tested on 
SIT-SERVER : [62b25860864b6f80ba46f797e325be86609fb32e](https://github.com/stayintarkov/SIT.Aki-Server-Mod/commit/efbfd0d86fbc4532a4a4f35a29c490be650f1d56)
SIT-CLIENT: b69c66d809e1c073ae846437bbe7f58521d220c2 to 4405145e9cde14a6e26e80dddfcc3db176549456
