### PR TITLE
Fix AkiBackendCommication bad delay

### DIFF
--- a/Source/Networking/AkiBackendCommunication.cs
+++ b/Source/Networking/AkiBackendCommunication.cs
@@ -732,15 +732,13 @@ namespace StayInTarkov.Networking
                     Logger.LogDebug($"Could not perform request to {url}");
                     Logger.LogDebug($"With Exception: {ex.Message}. {ex.InnerException?.Message}.");
                 }
-                finally
-                {
-                    await Task.Delay(timeout + 1);
 
-                    if (cts != null && !cts.IsCancellationRequested)
-                        cts.Cancel();
+                await Task.Delay(timeout + 1);
 
-                    retry++;
-                }
+                if (cts != null && !cts.IsCancellationRequested)
+                    cts.Cancel();
+
+                retry++;
 
             } while (retry < maxRetries);
 


### PR DESCRIPTION
Removes a `finally` that was causing an unnessary delay to all calls to Aki