### PR TITLE
missing session info on questcontroller

### DIFF
--- a/Source/Coop/Players/PlayerFactory.cs
+++ b/Source/Coop/Players/PlayerFactory.cs
@@ -20,7 +20,7 @@ namespace StayInTarkov.Coop.Players
     {
         public static QuestController GetQuestController(EFT.Profile profile, InventoryControllerClass inventoryController)
         {
-            var questController = new QuestController(profile, inventoryController, null, false);
+            var questController = new QuestController(profile, inventoryController, StayInTarkovHelperConstants.BackEndSession, true);
             questController.Init();
             questController.Run();
             return questController;


### PR DESCRIPTION
missing session info from questcontroller and request from server.
- resolves accepting quest from lightkeeper