### PR TITLE
Have freecam on death and also allow for first person following of pmcs

### DIFF
--- a/Source/Configuration/PluginConfigSettings.cs
+++ b/Source/Configuration/PluginConfigSettings.cs
@@ -121,12 +121,12 @@ namespace StayInTarkov.Configuration
 
             public int WaitingTimeBeforeStart { get; private set; }
 
-            public int BlackScreenOnDeathTime
+            public float BlackScreenOnDeathTime
             {
                 get
                 {
                     return StayInTarkovPlugin.Instance.Config.Bind
-                       ("Coop", "BlackScreenOnDeathTime", 500, new ConfigDescription("How long to wait until your death waits to become a Free Camera")).Value;
+                       ("Coop", "BlackScreenOnDeathTime", 5F, new ConfigDescription("How long to wait after death until you become a Free Camera")).Value;
                 }
             }
 

--- a/Source/Coop/FreeCamera/FreeCameraController.cs
+++ b/Source/Coop/FreeCamera/FreeCameraController.cs
@@ -1,13 +1,15 @@
-﻿using BSG.CameraEffects;
+﻿using BepInEx.Logging;
+using BSG.CameraEffects;
 using Comfort.Common;
 using EFT;
 using EFT.CameraControl;
 using EFT.UI;
-using HarmonyLib;
 using StayInTarkov.Configuration;
 using StayInTarkov.Coop.Components.CoopGameComponents;
+using StayInTarkov.Coop.Players;
 using StayInTarkov.Coop.SITGameModes;
 using System;
+using System.Collections;
 using UnityEngine;
 using UnityStandardAssets.ImageEffects;
 
@@ -27,15 +29,19 @@ namespace StayInTarkov.Coop.FreeCamera
         private bool _uiHidden;
 
         private GamePlayerOwner _gamePlayerOwner;
+        private DateTime _lastTime = DateTime.MinValue;
+
+        private ManualLogSource Logger { get; } = BepInEx.Logging.Logger.CreateLogSource("FreeCameraController");
+        private CoopPlayer Player => (CoopPlayer) Singleton<GameWorld>.Instance.MainPlayer;
 
         public GameObject CameraParent { get; set; }
         public Camera CameraFreeCamera { get; private set; }
         public Camera CameraMain { get; private set; }
 
-        void Awake()
+        protected void Awake()
         {
             CameraParent = new GameObject("CameraParent");
-            var FCamera = CameraParent.GetOrAddComponent<Camera>();
+            Camera FCamera = CameraParent.GetOrAddComponent<Camera>();
             FCamera.enabled = false;
         }
 
@@ -61,98 +67,92 @@ namespace StayInTarkov.Coop.FreeCamera
             {
                 return;
             }
+
+            Player.OnPlayerDead += Player_OnPlayerDead;
         }
 
-        private DateTime _lastTime = DateTime.MinValue;
+        private IEnumerator PlayerDeathRoutine()
+        {
+            yield return new WaitForSeconds(PluginConfigSettings.Instance.CoopSettings.BlackScreenOnDeathTime);
 
-        int DeadTime = 0;
+            var fpsCamInstance = CameraClass.Instance;
+            if (fpsCamInstance == null)
+            {
+                Logger.LogDebug("fpsCamInstance for camera is null");
+                yield break;
+            }
+
+            // Reset FOV after died
+            if (fpsCamInstance.Camera != null)
+                fpsCamInstance.Camera.fieldOfView = Singleton<SharedGameSettingsClass>.Instance.Game.Settings.FieldOfView;
+
+            EffectsController effectsController = fpsCamInstance.EffectsController;
+            if (effectsController == null)
+            {
+                Logger.LogDebug("effects controller for camera is null");
+                yield break;
+            }
+
+            DisableAndDestroyEffect(effectsController.GetComponent<DeathFade>());
+            DisableAndDestroyEffect(effectsController.GetComponent<FastBlur>());
+            DisableAndDestroyEffect(effectsController.GetComponent<EyeBurn>());
+            DisableAndDestroyEffect(effectsController.GetComponent<TextureMask>());
+            DisableAndDestroyEffect(effectsController.GetComponent<CC_Wiggle>());
+            DisableAndDestroyEffect(effectsController.GetComponent<CC_RadialBlur>());
+            DisableAndDestroyEffect(effectsController.GetComponent<MotionBlur>());
+            DisableAndDestroyEffect(effectsController.GetComponent<BloodOnScreen>());
+            DisableAndDestroyEffect(effectsController.GetComponent<GrenadeFlashScreenEffect>());
+            DisableAndDestroyEffect(effectsController.GetComponent<DepthOfField>());
+            //DisableAndDestroyEffect(effectsController.GetComponent<RainScreenDrops>());
+
+            var ccBlends = fpsCamInstance.EffectsController.GetComponents<CC_Blend>();
+            if (ccBlends != null)
+                foreach (var ccBlend in ccBlends)
+                    DisableAndDestroyEffect(ccBlend);
+
+            DisableAndDestroyEffect(fpsCamInstance.VisorEffect);
+            DisableAndDestroyEffect(fpsCamInstance.NightVision);
+            DisableAndDestroyEffect(fpsCamInstance.ThermalVision);
+
+            // Go to free camera mode
+            ToggleCamera();
+            ToggleUi();
+        }
+
+        private void Player_OnPlayerDead(EFT.Player player, IPlayer lastAggressor, DamageInfo damageInfo, EBodyPart part)
+        {
+            Player.OnPlayerDead -= Player_OnPlayerDead;
+            StartCoroutine(PlayerDeathRoutine());
+        }
 
         public void Update()
         {
             if (_gamePlayerOwner == null)
                 return;
 
-            if (_gamePlayerOwner.Player == null)
+            if (Player == null)
                 return;
 
-            if (_gamePlayerOwner.Player.PlayerHealthController == null)
+            if (Player.PlayerHealthController == null)
                 return;
 
-            if (!SITGameComponent.TryGetCoopGameComponent(out var coopGC))
+            if (!SITGameComponent.TryGetCoopGameComponent(out SITGameComponent coopGC))
                 return;
 
-            var coopGame = coopGC.LocalGameInstance as CoopSITGame;
+            CoopSITGame coopGame = coopGC.LocalGameInstance as CoopSITGame;
             if (coopGame == null)
                 return;
 
             var quitState = coopGC.GetQuitState();
-
-            if (_gamePlayerOwner.Player.PlayerHealthController.IsAlive
-                && (Input.GetKey(KeyCode.F9) || (quitState != SITGameComponent.EQuitState.NONE && !_freeCamScript.IsActive))
-                && _lastTime < DateTime.Now.AddSeconds(-3))
+            if (Player.PlayerHealthController.IsAlive && 
+                (Input.GetKey(KeyCode.F9) || (quitState != SITGameComponent.EQuitState.NONE && !_freeCamScript.IsActive)) && 
+                _lastTime < DateTime.Now.AddSeconds(-3))
             {
                 _lastTime = DateTime.Now;
                 ToggleCamera();
                 ToggleUi();
-            }
-
-            if (!_gamePlayerOwner.Player.PlayerHealthController.IsAlive)
-            {
-                // This is to make sure the screen effect remove code only get executed once, instead of running every frame.
-                if (DeadTime == -1)
-                    return;
-
-                if (DeadTime < PluginConfigSettings.Instance.CoopSettings.BlackScreenOnDeathTime)
-                {
-                    DeadTime++;
-                }
-                else
-                {
-                    DeadTime = -1;
-
-                    var fpsCamInstance = CameraClass.Instance;
-                    if (fpsCamInstance == null)
-                        return;
-
-                    // Reset FOV after died
-                    if (fpsCamInstance.Camera != null)
-                        fpsCamInstance.Camera.fieldOfView = Singleton<SharedGameSettingsClass>.Instance.Game.Settings.FieldOfView;
-
-                    var effectsController = fpsCamInstance.EffectsController;
-                    if (effectsController == null)
-                        return;
-
-                    DisableAndDestroyEffect(effectsController.GetComponent<DeathFade>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<FastBlur>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<EyeBurn>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<TextureMask>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<CC_Wiggle>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<CC_RadialBlur>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<MotionBlur>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<BloodOnScreen>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<GrenadeFlashScreenEffect>());
-                    DisableAndDestroyEffect(effectsController.GetComponent<DepthOfField>());
-                    //DisableAndDestroyEffect(effectsController.GetComponent<RainScreenDrops>());
-
-                    var ccBlends = fpsCamInstance.EffectsController.GetComponents<CC_Blend>();
-                    if (ccBlends != null)
-                        foreach (var ccBlend in ccBlends)
-                            DisableAndDestroyEffect(ccBlend);
-
-                    DisableAndDestroyEffect(fpsCamInstance.VisorEffect);
-                    DisableAndDestroyEffect(fpsCamInstance.NightVision);
-                    DisableAndDestroyEffect(fpsCamInstance.ThermalVision);
-
-                    // Go to free camera mode
-                    ToggleCamera();
-                    ToggleUi();
-                }
-            }
+            }            
         }
-
-        //DateTime? _lastOcclusionCullCheck = null;
-        //Vector3? _playerDeathOrExitPosition;
-        //bool showAtDeathOrExitPosition;
 
         /// <summary>
         /// Toggles the Freecam mode
@@ -160,8 +160,7 @@ namespace StayInTarkov.Coop.FreeCamera
         public void ToggleCamera()
         {
             // Get our own Player instance. Null means we're not in a raid
-            var localPlayer = GetLocalPlayerFromWorld();
-            if (localPlayer == null)
+            if (Player == null)
                 return;
 
             if (!_freeCamScript.IsActive)
@@ -169,16 +168,14 @@ namespace StayInTarkov.Coop.FreeCamera
                 GameObject[] allGameObject = Resources.FindObjectsOfTypeAll<GameObject>();
                 foreach (GameObject gobj in allGameObject)
                 {
-                    if (gobj.GetComponent<DisablerCullingObject>() != null)
-                    {
-                        gobj.GetComponent<DisablerCullingObject>().ForceEnable(true);
-                    }
+                    gobj.GetComponent<DisablerCullingObject>()?.ForceEnable(true);
                 }
-                SetPlayerToFreecamMode(localPlayer);
+                Logger.LogDebug($"Enabled Culling on {allGameObject.Length}.");
+                SetPlayerToFreecamMode(Player);
             }
             else
             {
-                SetPlayerToFirstPersonMode(localPlayer);
+                SetPlayerToFirstPersonMode(Player);
             }
         }
 
@@ -188,21 +185,20 @@ namespace StayInTarkov.Coop.FreeCamera
         public void ToggleUi()
         {
             // Check if we're currently in a raid
-            if (GetLocalPlayerFromWorld() == null)
+            if (Player == null)
                 return;
 
             // If we don't have the UI Component cached, go look for it in the scene
             if (_playerUi == null)
             {
-                var gameObject = GameObject.Find("BattleUIScreen");
+                GameObject gameObject = GameObject.Find("BattleUIScreen");
                 if (gameObject == null)
                     return;
 
                 _playerUi = gameObject.GetComponent<BattleUIScreen>();
-
                 if (_playerUi == null)
                 {
-                    //FreecamPlugin.Logger.LogError("Failed to locate player UI");
+                    Logger.LogError("Failed to locate player UI");
                     return;
                 }
             }
@@ -224,11 +220,9 @@ namespace StayInTarkov.Coop.FreeCamera
             // This means our character will be fully visible, while letting the camera move freely
             localPlayer.PointOfView = EPointOfView.ThirdPerson;
 
-            // Get the PlayerBody reference. It's a protected field, so we have to use traverse to fetch it
-            var playerBody = Traverse.Create(localPlayer).Field<PlayerBody>("_playerBody").Value;
-            if (playerBody != null)
+            if (localPlayer.PlayerBody != null)
             {
-                playerBody.PointOfView.Value = EPointOfView.FreeCamera;
+                localPlayer.PlayerBody.PointOfView.Value = EPointOfView.FreeCamera;
                 localPlayer.GetComponent<PlayerCameraController>().UpdatePointOfView();
             }
 
@@ -243,12 +237,6 @@ namespace StayInTarkov.Coop.FreeCamera
         private void SetPlayerToFirstPersonMode(EFT.Player localPlayer)
         {
             _freeCamScript.IsActive = false;
-
-            //if (FreecamPlugin.CameraRememberLastPosition.Value)
-            //{
-            //    _lastPosition = _mainCamera.transform.position;
-            //    _lastRotation = _mainCamera.transform.rotation;
-            //}
 
             // re-enable _gamePlayerOwner
             _gamePlayerOwner.enabled = true;
@@ -265,7 +253,7 @@ namespace StayInTarkov.Coop.FreeCamera
         private EFT.Player GetLocalPlayerFromWorld()
         {
             // If the GameWorld instance is null or has no RegisteredPlayers, it most likely means we're not in a raid
-            var gameWorld = Singleton<GameWorld>.Instance;
+            GameWorld gameWorld = Singleton<GameWorld>.Instance;
             if (gameWorld == null || gameWorld.MainPlayer == null)
                 return null;
 
@@ -284,7 +272,7 @@ namespace StayInTarkov.Coop.FreeCamera
 
         public void OnDestroy()
         {
-            GameObject.Destroy(CameraParent);
+            Destroy(CameraParent);
 
             // Destroy FreeCamScript before FreeCamController if exists
             Destroy(_freeCamScript);


### PR DESCRIPTION
Enables the freecam on death and updated the config to wait for the given number of seconds before changing from the black screen to the freecam with the default set to 5s.

Also added the ability to follow/spectate PMCs in first person (I didn't know how to filter to just human players but I think that would be prefereable)

- Left Mouse Button goes to the next player.
- Right Mouse Button goes to the previous player
- End unlocks the camera again so you can fly around freely.